### PR TITLE
Fix sending two responses for HTTP error

### DIFF
--- a/src/reduct/api/api_server.cc
+++ b/src/reduct/api/api_server.cc
@@ -307,8 +307,8 @@ class ApiServer : public IApiServer {
         .stop_timestamp = stop_ts,
     };
 
-    auto on_success = [](IListEntryCallback::Response app_resp) { return PrintToJson(app_resp); };
-    handler.Run(co_await storage_->OnListEntry(data), on_success);
+    handler.Run(co_await storage_->OnListEntry(data),
+                [](IListEntryCallback::Response app_resp) { return PrintToJson(app_resp); });
     co_return;
   }
 

--- a/src/reduct/api/common.h
+++ b/src/reduct/api/common.h
@@ -80,11 +80,12 @@ class BasicApiHandler {
   }
 
   void Run(
-      typename Callback::Result result,
+      typename Callback::Result&& result,
       std::function<std::string(typename Callback::Response)> on_success = [](auto) { return ""; }) const noexcept {
     auto [resp, err] = std::move(result);
     if (err) {
       SendError(err);
+      return;
     }
 
     LOG_DEBUG("{} {}: OK", method_, url_);


### PR DESCRIPTION
If a storage has an error, it sends the response twice:
* First with detail
* Second as an empty string