### PR TITLE
Fix handling offset in tryEnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bugs**:
 
 * Fix sending big blobs [PR-80](https://github.com/reduct-storage/reduct-storage/pull/80)
+* Fix handling offset in tryEnd [PR-81](https://github.com/reduct-storage/reduct-storage/pull/81)
 
 ### Release 0.4.2 (2022-04-30)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(REDUCT_BUILD_TEST "Build unit tests" ON)
 
 
 set(DEFAULT_MAX_BLOCK_SIZE 67108864 CACHE STRING "Default max size for block with data")
-set(DEFAULT_MAX_READ_CHUNK 65536 CACHE STRING "Default max chunk for reading")
+set(DEFAULT_MAX_READ_CHUNK 524288 CACHE STRING "Default max chunk for reading")
 
 project(reduct_storage VERSION ${FULL_VERSION})
 

--- a/api_tests/requirements.txt
+++ b/api_tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest~=6.2
 pylint~=2.12
 requests~=2.26
+numpy

--- a/src/reduct/api/api_server.cc
+++ b/src/reduct/api/api_server.cc
@@ -364,7 +364,7 @@ class ApiServer : public IApiServer {
 
     bool complete = false;
     while (!aborted && !complete) {
-      co_await Sleep(async::kTick); // switch context before start to read
+      co_await Sleep(async::kTick);  // switch context before start to read
       auto [chuck, read_err] = reader->Read();
       if (read_err) {
         handler.SendError(err);

--- a/src/reduct/api/api_server.cc
+++ b/src/reduct/api/api_server.cc
@@ -362,28 +362,25 @@ class ApiServer : public IApiServer {
       aborted = true;
     });
 
-    size_t sent = 0;
-    while (!aborted) {
+    bool complete = false;
+    while (!aborted && !complete) {
+      co_await Sleep(async::kTick); // switch context before start to read
       auto [chuck, read_err] = reader->Read();
       if (read_err) {
         handler.SendError(err);
         co_return;
       }
 
-      if (chuck.data.empty()) {
-        break;
-      }
-
+      const auto offset = res->getWriteOffset();
       while (!aborted) {
         ready_to_continue = false;
-        auto [ok, _] = res->tryEnd(chuck.data, reader->size());
-        co_await Sleep(async::kTick);
+        auto [ok, responded] = res->tryEnd(chuck.data.substr(res->getWriteOffset() - offset), reader->size());
         if (ok) {
-          sent += chuck.data.size();
+          complete = responded;
           break;
         } else {
           // Have to wait until onWritable sets flag
-          LOG_DEBUG("Failed to send data. Abort. {} {}/{} kB", ts, sent / 1024, reader->size() / 1024);
+          LOG_DEBUG("Failed to send data: {} {}/{} kB", ts, res->getWriteOffset() / 1024, reader->size() / 1024);
           while (!ready_to_continue && !aborted) {
             co_await Sleep(async::kTick);
           }
@@ -393,7 +390,7 @@ class ApiServer : public IApiServer {
       }
     }
 
-    LOG_DEBUG("Sent {} {}/{} kB", ts, sent / 1024, reader->size() / 1024);
+    LOG_DEBUG("Sent {} {}/{} kB", ts, res->getWriteOffset() / 1024, reader->size() / 1024);
     co_return;
   }
 


### PR DESCRIPTION
If the whole chunk is not sent, we should repeat sending with from the latest byte which was sent.