### PR TITLE
Fix updating record state in asynchronous write operation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix Web Console for RS_API_BASE_PATH, [PR-92](https://github.com/reduct-storage/reduct-storage/pull/92)
 * Fix wasting disk space in FSX filesystem, [PR-100](https://github.com/reduct-storage/reduct-storage/pull/100)
 * Fix base path in server url, [PR-105](https://github.com/reduct-storage/reduct-storage/pull/105)
-
+* Fix updating record state in asynchronous write operation, [PR-109](https://github.com/reduct-storage/reduct-storage/pull/109)
 **Other**:
 
 * Optimise write operation, [PR-96](https://github.com/reduct-storage/reduct-storage/pull/96)

--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/reduct-storage/web-console:v0.1.0 AS web-console
+FROM ghcr.io/reduct-storage/web-console:main AS web-console
 FROM gcc:11.2 AS builder
 
 RUN apt update && apt install -y cmake python3-pip zip

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -163,7 +163,11 @@ class Entry : public IEntry {
     auto writer = BuildAsyncWriter(
         *block,
         {.path = BlockPath(full_path_, *block), .record_index = block->records_size() - 1, .size = content_size},
-        [this, block](int index, auto state) {
+        [this, ts = block->begin_time()](int index, auto state) {
+          auto [block, load_err] = block_manager_->LoadBlock(ts);
+          if (load_err) {
+            LOG_ERROR("{}", load_err.ToString());
+          }
           block->mutable_records(index)->set_state(state);
           if (auto err = block_manager_->SaveBlock(block)) {
             LOG_ERROR("{}", err.ToString());


### PR DESCRIPTION
When a written record changes its state, we have to write in into descriptor. We have to reload it. 