### PR TITLE
Fix load bucket settings from disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
   operation, [PR-109](https://github.com/reduct-storage/reduct-storage/pull/109)
 * Fix SEGFAULT when entry removed but async writer is
   alive, [PR-110](https://github.com/reduct-storage/reduct-storage/pull/110)
-* Fix removing a block with active readers or writers [PR-111](https://github.com/reduct-storage/reduct-storage/pull/111)
+* Fix removing a block with active readers or writers, [PR-111](https://github.com/reduct-storage/reduct-storage/pull/111)
+* Fix load bucket settings from disk, [PR-112](https://github.com/reduct-storage/reduct-storage/pull/112)
 
 **Other**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Fix SEGFAULT when entry removed but async writer is
   alive, [PR-110](https://github.com/reduct-storage/reduct-storage/pull/110)
 * Fix removing a block with active readers or writers, [PR-111](https://github.com/reduct-storage/reduct-storage/pull/111)
-* Fix load bucket settings from disk, [PR-112](https://github.com/reduct-storage/reduct-storage/pull/112)
+* Fix loading bucket settings from disk, [PR-112](https://github.com/reduct-storage/reduct-storage/pull/112)
 
 **Other**:
 

--- a/src/reduct/storage/bucket.cc
+++ b/src/reduct/storage/bucket.cc
@@ -70,6 +70,7 @@ class Bucket : public IBucket {
 
     settings_.ParseFromIstream(&settings_file);
 
+
     for (const auto& folder : fs::directory_iterator(full_path_)) {
       if (fs::is_directory(folder)) {
         auto entry_name = folder.path().filename().string();
@@ -77,6 +78,7 @@ class Bucket : public IBucket {
             .name = folder.path().filename().string(),
             .path = folder.path().parent_path().string(),
             .max_block_size = settings_.max_block_size(),
+            .max_block_records = settings_.max_block_records(),
         });
         if (entry) {
           entry_map_[entry_name] = std::move(entry);

--- a/unit_tests/reduct/storage/bucket_test.cc
+++ b/unit_tests/reduct/storage/bucket_test.cc
@@ -36,6 +36,8 @@ TEST_CASE("storage::Bucket should restore from folder", "[bucket]") {
   settings.set_max_block_size(100);
   settings.set_quota_type(BucketSettings::FIFO);
   settings.set_quota_size(1000);
+  settings.set_max_block_records(2000);
+
   auto bucket = IBucket::Build(dir_path / "bucket", settings);
 
   REQUIRE(bucket->GetOrCreateEntry("entry1").error == Error::kOk);


### PR DESCRIPTION
`max_block_records` parameter wasn't loaded from disk at the storage's start. 