### PR TITLE
[#130] Use SI for max block and read chunk sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed:
 
-- Use `Keep a log` format for CHANGLOG, [PR-136](https://github.com/reduct-storage/reduct-storage/pull/136)
+- Use `Keep a log` format for CHANGELOG, [PR-136](https://github.com/reduct-storage/reduct-storage/pull/136)
+- SI for max block and read chunk sizes, [PR-137](https://github.com/reduct-storage/reduct-storage/pull/137)
 
 ### Fixed:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ option(REDUCT_BUILD_TEST "Build unit tests" ON)
 option(REDUCT_BUILD_BENCHMARKS "Build unit tests" ON)
 
 
-set(DEFAULT_MAX_BLOCK_SIZE 67108864 CACHE STRING "Default max size for block with data")
+set(DEFAULT_MAX_BLOCK_SIZE 64000000 CACHE STRING "Default max size for block with data")
 set(DEFAULT_MAX_BLOCK_RECORDS 1024 CACHE STRING "Default max number of records in a block")
-set(DEFAULT_MAX_READ_CHUNK 524288 CACHE STRING "Default max chunk for reading")
+set(DEFAULT_MAX_READ_CHUNK 512000 CACHE STRING "Default max chunk for reading")
 set(WEB_CONSOLE_PATH "" CACHE STRING "Path to the built web console")
 
 project(reduct_storage VERSION ${FULL_VERSION})

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -12,7 +12,7 @@ def test_create_bucket_ok(base_url, session, bucket_name):
     assert resp.status_code == 200
 
     data = json.loads(resp.content)
-    assert data['settings'] == {"max_block_records": "1024", "max_block_size": str(64 * 1024 * 1024),
+    assert data['settings'] == {"max_block_records": "1024", "max_block_size": "64000000",
                                 "quota_type": "NONE", "quota_size": '0'}
     assert data['info']['name'] == bucket_name
     assert len(data['entries']) == 0

--- a/api_tests/server_api_test.py
+++ b/api_tests/server_api_test.py
@@ -13,7 +13,7 @@ def test_get_info(base_url, session):
     assert int(data['latest_record']) >= 0
     assert int(data['oldest_record']) >= 0
 
-    assert data['defaults']['bucket'] == {'max_block_records': '1024', 'max_block_size': '67108864', 'quota_size': '0',
+    assert data['defaults']['bucket'] == {'max_block_records': '1024', 'max_block_size': '64000000', 'quota_size': '0',
                                           'quota_type': 'NONE'}
     assert resp.headers['server'] == "ReductStorage"
     assert resp.headers['Content-Type'] == "application/json"


### PR DESCRIPTION
Closes #130

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Change

### What is the current behavior?

Max block size is 64 MiB

### What is the new behavior?

Now it is 64 Mb what is compatible with Web Console

### Does this PR introduce a breaking change?** 

No
