### PR TITLE
[#125] Fix update of bucket settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GET `/b/:bucket/:entry` to avoid creating an empty
   entry, [PR-95](https://github.com/reduct-storage/reduct-storage/pull/95)
+- Update of bucket settings, [PR-138](https://github.com/reduct-storage/reduct-storage/pull/138)
 
 ## [0.5.0] - 2022-05-15
 

--- a/src/reduct/storage/bucket.cc
+++ b/src/reduct/storage/bucket.cc
@@ -56,12 +56,11 @@ class Bucket : public IBucket {
     for (const auto& folder : fs::directory_iterator(full_path_)) {
       if (fs::is_directory(folder)) {
         auto entry_name = folder.path().filename().string();
-        auto entry = IEntry::Build(IEntry::Options{
-            .name = folder.path().filename().string(),
-            .path = folder.path().parent_path().string(),
-            .max_block_size = settings_.max_block_size(),
-            .max_block_records = settings_.max_block_records(),
-        });
+        auto entry = IEntry::Build(folder.path().filename().string(), folder.path().parent_path().string(),
+                                   {
+                                       .max_block_size = settings_.max_block_size(),
+                                       .max_block_records = settings_.max_block_records(),
+                                   });
         if (entry) {
           entry_map_[entry_name] = std::move(entry);
         } else {
@@ -77,12 +76,11 @@ class Bucket : public IBucket {
       return {it->second, Error::kOk};
     } else {
       LOG_DEBUG("No '{}' entry in a bucket. Try to create one", name);
-      auto entry = IEntry::Build({
-          .name = name,
-          .path = full_path_,
-          .max_block_size = settings_.max_block_size(),
-          .max_block_records = settings_.max_block_records(),
-      });
+      auto entry = IEntry::Build(name, full_path_,
+                                 {
+                                     .max_block_size = settings_.max_block_size(),
+                                     .max_block_records = settings_.max_block_records(),
+                                 });
 
       if (entry) {
         std::shared_ptr<IEntry> ptr = std::move(entry);

--- a/src/reduct/storage/bucket.cc
+++ b/src/reduct/storage/bucket.cc
@@ -137,6 +137,12 @@ class Bucket : public IBucket {
 
   Error SetSettings(BucketSettings settings) override {
     settings_ = InitSettings(std::move(settings), settings_);
+    for (auto [key, entry] : entry_map_) {
+      entry->SetOptions({
+          .max_block_size = settings_.max_block_size(),
+          .max_block_records = settings_.max_block_records(),
+      });
+    }
     return SaveDescriptor();
   }
 

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -34,8 +34,9 @@ class Entry : public IEntry {
    * Create a new entry
    * @param options
    */
-  explicit Entry(Options options) : options_(std::move(options)), block_set_(), size_counter_{}, record_counter_{} {
-    full_path_ = options_.path / options_.name;
+  Entry(std::string_view name, std::filesystem::path path, Options options)
+      : name_(name), options_(std::move(options)), block_set_(), size_counter_{}, record_counter_{} {
+    full_path_ = path / name_;
     block_manager_ = IBlockManager::Build(full_path_);
     if (!fs::create_directories(full_path_)) {
       for (const auto& file : fs::directory_iterator(full_path_)) {
@@ -182,7 +183,7 @@ class Entry : public IEntry {
 
     auto [block, err] = FindBlock(proto_ts);
     if (err) {
-      LOG_ERROR("No block in entry '{}' for ts={}", options_.name, TimeUtil::ToString(proto_ts));
+      LOG_ERROR("No block in entry '{}' for ts={}", name_, TimeUtil::ToString(proto_ts));
       return {{}, {.code = 500, .message = "Failed to find the needed block in descriptor"}};
     }
 
@@ -306,7 +307,7 @@ class Entry : public IEntry {
     }
 
     EntryInfo info;
-    info.set_name(options_.name);
+    info.set_name(name_);
     info.set_size(size_counter_);
     info.set_record_count(record_counter_);
     info.set_block_count(block_set_.size());
@@ -352,6 +353,7 @@ class Entry : public IEntry {
     return Error::kOk;
   }
 
+  std::string name_;
   Options options_;
   fs::path full_path_;
 
@@ -361,7 +363,9 @@ class Entry : public IEntry {
   size_t record_counter_;
 };
 
-std::unique_ptr<IEntry> IEntry::Build(IEntry::Options options) { return std::make_unique<Entry>(std::move(options)); }
+std::unique_ptr<IEntry> IEntry::Build(std::string_view name, const fs::path& path, IEntry::Options options) {
+  return std::make_unique<Entry>(name, path, std::move(options));
+}
 
 /**
  * Streams

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -319,6 +319,8 @@ class Entry : public IEntry {
 
   [[nodiscard]] const Options& GetOptions() const override { return options_; }
 
+  void SetOptions(const Options& options) override { options_ = options; }
+
  private:
   Result<IBlockManager::BlockSPtr> FindBlock(Timestamp proto_ts) const {
     auto ts = block_set_.upper_bound(proto_ts);

--- a/src/reduct/storage/entry.h
+++ b/src/reduct/storage/entry.h
@@ -23,10 +23,8 @@ class IEntry {
    * Options
    */
   struct Options {
-    std::string name;            // name of entry
-    std::filesystem::path path;  // path to entry (path to bucket)
-    size_t max_block_size;       // max block quota_size after that we create a new one
-    size_t max_block_records;    // max number of records in a block
+    size_t max_block_size;     // max block quota_size after that we create a new one
+    size_t max_block_records;  // max number of records in a block
 
     bool operator<=>(const Options& rhs) const = default;
   };
@@ -93,7 +91,7 @@ class IEntry {
    * @param options
    * @return pointer to entre or nullptr if failed to create
    */
-  static std::unique_ptr<IEntry> Build(Options options);
+  static std::unique_ptr<IEntry> Build(std::string_view name, const std::filesystem::path& path, Options options);
 
   /**
    * @brief Restores entry from dir

--- a/src/reduct/storage/entry.h
+++ b/src/reduct/storage/entry.h
@@ -86,6 +86,12 @@ class IEntry {
   [[nodiscard]] virtual const Options& GetOptions() const = 0;
 
   /**
+   * @brief Set options
+   * @return
+   */
+  virtual void SetOptions(const Options&) = 0;
+
+  /**
    * @brief Creates a new entry.
    * Directory path/name must be empty
    * @param options

--- a/unit_tests/reduct/storage/async_io_test.cc
+++ b/unit_tests/reduct/storage/async_io_test.cc
@@ -14,18 +14,19 @@ using reduct::async::IAsyncReader;
 
 using std::chrono::seconds;
 
+std::string_view kName = "entry_1";
+
 static auto MakeDefaultOptions() {
   return IEntry::Options{
-      .name = "entry_1",
-      .path = BuildTmpDirectory(),
       .max_block_size = 1000,
+      .max_block_records = 100,
   };
 }
 
 static const auto kTimestamp = IEntry::Time();
 
 TEST_CASE("AsyncWriter should provide async writing in the same block") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   auto [writer_1, err_1] = entry->BeginWrite(kTimestamp, 10);
@@ -44,7 +45,7 @@ TEST_CASE("AsyncWriter should provide async writing in the same block") {
 }
 
 TEST_CASE("AsyncWriter should check size") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   auto [writer, err] = entry->BeginWrite(kTimestamp, 10);
@@ -53,7 +54,7 @@ TEST_CASE("AsyncWriter should check size") {
 }
 
 TEST_CASE("AsyncWriter should mark finished records") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   auto [writer, err] = entry->BeginWrite(kTimestamp, 10);
@@ -66,7 +67,7 @@ TEST_CASE("AsyncWriter should mark finished records") {
 }
 
 TEST_CASE("AsyncReader should read a big file in two chunks") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   const auto size = reduct::kDefaultMaxReadChunk * 2 - 1;
@@ -80,13 +81,13 @@ TEST_CASE("AsyncReader should read a big file in two chunks") {
 }
 
 TEST_CASE("AsyncReader should not spoil data") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   const auto size = reduct::kDefaultMaxReadChunk - 1;
   std::string blob(size, 'a');
   for (int i = 0; i < size; ++i) {
-    blob[i] = static_cast<char>(rand() % 127); // NOLINT
+    blob[i] = static_cast<char>(rand() % 127);  // NOLINT
   }
 
   REQUIRE(WriteOne(*entry, blob, kTimestamp) == Error::kOk);

--- a/unit_tests/reduct/storage/bucket_test.cc
+++ b/unit_tests/reduct/storage/bucket_test.cc
@@ -65,7 +65,6 @@ TEST_CASE("storage::Bucket should create get or create entry", "[bucket][entry]"
     REQUIRE(entry.lock());
     auto options = entry.lock()->GetOptions();
 
-    REQUIRE(options.name == "entry_1");
     REQUIRE(options.max_block_size == bucket->GetSettings().max_block_size());
     REQUIRE(options.max_block_records == bucket->GetSettings().max_block_records());
   }

--- a/unit_tests/reduct/storage/bucket_test.cc
+++ b/unit_tests/reduct/storage/bucket_test.cc
@@ -4,6 +4,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "reduct/config.h"
 #include "reduct/helpers.h"
 
 using reduct::core::Error;
@@ -172,4 +173,19 @@ TEST_CASE("storage::Bucket should change quota settings and save it", "[bucket]"
   bucket = IBucket::Restore(dir_path / "bucket");
   REQUIRE(bucket->GetSettings().quota_size() == settings.quota_size());
   REQUIRE(bucket->GetSettings().quota_type() == settings.quota_type());
+}
+
+TEST_CASE("storage::Bucket should change block settings and apply them", "[bucket]") {
+  const auto dir_path = BuildTmpDirectory();
+  auto bucket = IBucket::Build(dir_path / "bucket");
+
+  auto entry = bucket->GetOrCreateEntry("test-entry").entry.lock();
+  REQUIRE(entry->GetOptions().max_block_size == reduct::kDefaultMaxBlockSize);
+
+  BucketSettings settings;
+  settings.set_max_block_size(1);
+  REQUIRE(bucket->SetSettings(settings) == Error::kOk);
+  REQUIRE(bucket->GetSettings().max_block_size() == settings.max_block_size());
+
+  REQUIRE(entry->GetOptions().max_block_size == 1);
 }

--- a/unit_tests/reduct/storage/bucket_test.cc
+++ b/unit_tests/reduct/storage/bucket_test.cc
@@ -179,12 +179,14 @@ TEST_CASE("storage::Bucket should change block settings and apply them", "[bucke
   auto bucket = IBucket::Build(dir_path / "bucket");
 
   auto entry = bucket->GetOrCreateEntry("test-entry").entry.lock();
-  REQUIRE(entry->GetOptions().max_block_size == reduct::kDefaultMaxBlockSize);
 
   BucketSettings settings;
   settings.set_max_block_size(1);
+  settings.set_max_block_records(2);
+
   REQUIRE(bucket->SetSettings(settings) == Error::kOk);
   REQUIRE(bucket->GetSettings().max_block_size() == settings.max_block_size());
 
   REQUIRE(entry->GetOptions().max_block_size == 1);
+  REQUIRE(entry->GetOptions().max_block_records == 2);
 }

--- a/unit_tests/reduct/storage/entry_test.cc
+++ b/unit_tests/reduct/storage/entry_test.cc
@@ -129,7 +129,8 @@ TEST_CASE("storage::Entry should resize finished block") {
 }
 
 TEST_CASE("storage::Entry start a new block if it has more records than max_block_records") {
-  const auto options = MakeDefaultOptions();
+  auto options = MakeDefaultOptions();
+  options.max_block_records = 2;
   const auto path = BuildTmpDirectory();
   auto entry = IEntry::Build(kName, path, options);
 
@@ -208,7 +209,8 @@ TEST_CASE("storage::Entry should read from empty entry with 404", "[entry]") {
 }
 
 TEST_CASE("storage::Entry should remove last block", "[entry]") {
-  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
+  const auto path = BuildTmpDirectory();
+  auto entry = IEntry::Build(kName, path, MakeDefaultOptions());
   REQUIRE(entry);
 
   const std::string blob(entry->GetOptions().max_block_size + 1, 'x');
@@ -235,7 +237,7 @@ TEST_CASE("storage::Entry should remove last block", "[entry]") {
 
     SECTION("recovery") {
       auto info = entry->GetInfo();
-      entry = IEntry::Build(kName, BuildTmpDirectory(), entry->GetOptions());
+      entry = IEntry::Build(kName, path, entry->GetOptions());
 
       REQUIRE(entry);
       REQUIRE(entry->GetInfo() == info);

--- a/unit_tests/reduct/storage/entry_test.cc
+++ b/unit_tests/reduct/storage/entry_test.cc
@@ -19,10 +19,10 @@ using google::protobuf::util::TimeUtil;
 using std::chrono::seconds;
 namespace fs = std::filesystem;
 
+const auto kName = "entry_1";
+
 static auto MakeDefaultOptions() {
   return IEntry::Options{
-      .name = "entry_1",
-      .path = BuildTmpDirectory(),
       .max_block_size = 100,
       .max_block_records = 1024,
   };
@@ -34,15 +34,15 @@ auto ToMicroseconds(IEntry::Time tp) {
   return std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()).count();
 }
 
-auto GetBlockSize(IEntry::Options options, IEntry::Time begin_ts) {
+auto GetBlockSize(std::string_view name, fs::path path, IEntry::Options options, IEntry::Time begin_ts) {
   return fs::file_size(
-      options.path / options.name /
+      path / name /
       fmt::format("{}.blk",
                   std::chrono::duration_cast<std::chrono::microseconds>(begin_ts.time_since_epoch()).count()));
 }
 
 TEST_CASE("storage::Entry should record data to a block", "[entry]") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   REQUIRE(WriteOne(*entry, "some_data", kTimestamp) == Error::kOk);
@@ -82,7 +82,7 @@ TEST_CASE("storage::Entry should record data to a block", "[entry]") {
 }
 
 TEST_CASE("storage::Entry should create a new block if the current > max_block_size", "[entry]") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   auto big_data = std::string(MakeDefaultOptions().max_block_size + 1, 'c');
@@ -116,45 +116,47 @@ TEST_CASE("storage::Entry should create a new block if the current > max_block_s
 
 TEST_CASE("storage::Entry should resize finished block") {
   const auto options = MakeDefaultOptions();
-  auto entry = IEntry::Build(options);
+  const auto path = BuildTmpDirectory();
+  auto entry = IEntry::Build(kName, path, options);
   REQUIRE(entry);
 
   auto big_data = std::string(options.max_block_size - 10, 'c');
   REQUIRE(WriteOne(*entry, big_data, kTimestamp) == Error::kOk);
   REQUIRE(WriteOne(*entry, big_data, kTimestamp + seconds(1)) == Error::kOk);
 
-  REQUIRE(GetBlockSize(options, kTimestamp) == big_data.size());
-  REQUIRE(GetBlockSize(options, kTimestamp + seconds(1)) == options.max_block_size);
+  REQUIRE(GetBlockSize(kName, path, options, kTimestamp) == big_data.size());
+  REQUIRE(GetBlockSize(kName, path, options, kTimestamp + seconds(1)) == options.max_block_size);
 }
 
 TEST_CASE("storage::Entry start a new block if it has more records than max_block_records") {
-  auto options = MakeDefaultOptions();
-  options.max_block_records = 2;
+  const auto options = MakeDefaultOptions();
+  const auto path = BuildTmpDirectory();
+  auto entry = IEntry::Build(kName, path, options);
 
-  auto entry = IEntry::Build(options);
   REQUIRE(entry);
 
   REQUIRE(WriteOne(*entry, "data", kTimestamp) == Error::kOk);
   REQUIRE(WriteOne(*entry, "data", kTimestamp + seconds(1)) == Error::kOk);
   REQUIRE(WriteOne(*entry, "data", kTimestamp + seconds(2)) == Error::kOk);
 
-  REQUIRE(GetBlockSize(options, kTimestamp) == 8);
-  REQUIRE(GetBlockSize(options, kTimestamp + seconds(2)) == options.max_block_size);
+  REQUIRE(GetBlockSize(kName, path, options, kTimestamp) == 8);
+  REQUIRE(GetBlockSize(kName, path, options, kTimestamp + seconds(2)) == options.max_block_size);
 }
 
 TEST_CASE("storage::Entry should create block with size of record it  is bigger than max_block_size") {
   const auto options = MakeDefaultOptions();
-  auto entry = IEntry::Build(options);
+  const auto path = BuildTmpDirectory();
+  auto entry = IEntry::Build(kName, path, options);
   REQUIRE(entry);
 
   auto big_data = std::string(options.max_block_size + 10, 'c');
   REQUIRE(WriteOne(*entry, big_data, kTimestamp) == Error::kOk);
 
-  REQUIRE(GetBlockSize(options, kTimestamp) == big_data.size());
+  REQUIRE(GetBlockSize(kName, path, options, kTimestamp) == big_data.size());
 }
 
 TEST_CASE("storage::Entry should write data for random kTimestamp", "[entry]") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   auto big_blob = std::string(100, 'c');
@@ -177,10 +179,12 @@ TEST_CASE("storage::Entry should write data for random kTimestamp", "[entry]") {
 
 TEST_CASE("storage::Entry should restore itself from folder", "[entry]") {
   const auto options = MakeDefaultOptions();
-  auto entry = IEntry::Build(options);
+  const auto path = BuildTmpDirectory();
+  auto entry = IEntry::Build(kName, path, options);
+
   REQUIRE(entry);
   REQUIRE(WriteOne(*entry, "some_data", kTimestamp) == Error::kOk);
-  entry = IEntry::Build(options);
+  entry = IEntry::Build(kName, path, options);
   REQUIRE(entry->GetOptions() == options);
 
   const auto info = entry->GetInfo();
@@ -197,14 +201,14 @@ TEST_CASE("storage::Entry should restore itself from folder", "[entry]") {
 }
 
 TEST_CASE("storage::Entry should read from empty entry with 404", "[entry]") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
 
   REQUIRE(entry);
   REQUIRE(ReadOne(*entry, IEntry::Time()).error.code == 404);
 }
 
 TEST_CASE("storage::Entry should remove last block", "[entry]") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   const std::string blob(entry->GetOptions().max_block_size + 1, 'x');
@@ -231,7 +235,7 @@ TEST_CASE("storage::Entry should remove last block", "[entry]") {
 
     SECTION("recovery") {
       auto info = entry->GetInfo();
-      entry = IEntry::Build(entry->GetOptions());
+      entry = IEntry::Build(kName, BuildTmpDirectory(), entry->GetOptions());
 
       REQUIRE(entry);
       REQUIRE(entry->GetInfo() == info);
@@ -240,7 +244,7 @@ TEST_CASE("storage::Entry should remove last block", "[entry]") {
 }
 
 TEST_CASE("storage::Entry should list records for time interval", "[entry]") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   SECTION("empty record") {
@@ -341,7 +345,7 @@ TEST_CASE("storage::Entry should list records for time interval", "[entry]") {
 }
 
 TEST_CASE("storage::Entry should not list records which is not finished") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   auto writer = entry->BeginWrite(kTimestamp, 1).result;
@@ -352,7 +356,7 @@ TEST_CASE("storage::Entry should not list records which is not finished") {
 }
 
 TEST_CASE("storage::Entry should wait when read operations finish before removing block") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   REQUIRE(WriteOne(*entry, "blob", kTimestamp) == Error::kOk);
@@ -368,7 +372,7 @@ TEST_CASE("storage::Entry should wait when read operations finish before removin
 }
 
 TEST_CASE("storage::Entry should wait when write operations finish before removing block") {
-  auto entry = IEntry::Build(MakeDefaultOptions());
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);
 
   auto [writer, err] = entry->BeginWrite(kTimestamp, 5);


### PR DESCRIPTION
Closes #125 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug Fix 

### What is the current behavior?

Bucket doesn't apply new settings to entries when they are changed. 

### What is the new behavior?

`IEntry` has a setter to update settings after it was created.  Bucket uses it for updating, then its settigns is changed. 

### Does this PR introduce a breaking change?** 

No 

### Other information:
