### PR TITLE
Fix infinite loop in Bucket::KeepQuota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed:
+
+- Infinite loop in Bucket::KeepQuota, [PR-146](https://github.com/reduct-storage/reduct-storage/pull/146)
+
 ## [0.7.1] - 2022-07-30
 
 ### Fixed:

--- a/src/reduct/storage/bucket.cc
+++ b/src/reduct/storage/bucket.cc
@@ -115,8 +115,8 @@ class Bucket : public IBucket {
           std::vector<EntryInfo> candidates(std::ranges::begin(rr), std::ranges::end(rr));
           std::ranges::sort(candidates, [](auto& a, auto& b) { return a.oldest_record() < b.oldest_record(); });
 
-          for (int i = 0; i < candidates.size(); ++i) {
-            const auto& entry = candidates[i];
+          bool success = false;
+          for (auto& entry : candidates) {
             LOG_DEBUG("Remove the oldest block in entry '{}'", entry.name());
             auto entry_ptr = entry_map_.at(entry.name());
             err = entry_ptr->RemoveOldestBlock();
@@ -127,8 +127,13 @@ class Bucket : public IBucket {
               }
 
               bucket_size = GetInfo().size();
+              success = true;
               break;
             }
+          }
+
+          if (!success) {
+            return {.code = 500, .message = "No blocks to remove"};
           }
         }
     }

--- a/src/reduct/storage/storage.cc
+++ b/src/reduct/storage/storage.cc
@@ -193,7 +193,7 @@ class Storage : public IStorage {
       auto [bucket_it, _] = FindBucket(req.bucket_name);
       auto quota_error = bucket_it->second->KeepQuota();
       if (quota_error) {
-        LOG_ERROR("Didn't mange to keep quota: {}", quota_error.ToString());
+        LOG_WARNING("Didn't mange to keep quota: {}", quota_error.ToString());
       }
     }
 


### PR DESCRIPTION
Closes #144

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

If there is no block to remove to keep quota, we have an infinite loop and the engine hangs up.

### What is the new behavior?

We have a warning message in logs that we didn't manage to keep quota. 

### Does this PR introduce a breaking change?** 

Not 

### Other information:
