### PR TITLE
Duplication of timestamps is not allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Infinite loop in Bucket::KeepQuota, [PR-146](https://github.com/reduct-storage/reduct-storage/pull/146)
 
+
+## Changed:
+
+- Duplication of timestamps is not allowed, [PR147](https://github.com/reduct-storage/reduct-storage/pull/147)
+
 ## [0.7.1] - 2022-07-30
 
 ### Fixed:

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -1,4 +1,4 @@
----
++---
 description: Entry API provides methods to write, read and browse the data
 ---
 
@@ -37,6 +37,14 @@ Content-length is required to start an asynchronous write operation
 ```javascript
 {
     "detail": "string"
+}
+```
+{% endswagger-response %}
+
+{% swagger-response status="409: Conflict" description="A record with the same timestamp already exists" %}
+```javascript
+{
+   "detail": "string"
 }
 ```
 {% endswagger-response %}
@@ -104,7 +112,7 @@ A UNIX timestamp in microseconds. If it is empty, the latest record is returned.
 
 {% swagger method="get" path="" baseUrl="/b/:bucket_name/:entry_name/q " summary="Query records for a time interval" %}
 {% swagger-description %}
-The method response with a JSON document with ID which can be used to integrate records with method 
+The method response with a JSON document with ID which can be used to integrate records with method
 
 **GET /b/:bucket_name/:entry_name?q=ID.**
 
@@ -134,7 +142,7 @@ Time To Live of the query in seconds. If a client haven't read any record for th
 {% swagger-response status="200: OK" description="" %}
 ```javascript
 {
-   "id": "integer" // ID of query wich can be used in GET /b/:bucket/:entry request 
+   "id": "integer" // ID of query wich can be used in GET /b/:bucket/:entry request
 }
 ```
 {% endswagger-response %}

--- a/unit_tests/reduct/storage/entry_test.cc
+++ b/unit_tests/reduct/storage/entry_test.cc
@@ -82,6 +82,15 @@ TEST_CASE("storage::Entry should record data to a block", "[entry]") {
   }
 }
 
+TEST_CASE("storage::Entry should not overwrite record", "[entry]") {
+  auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
+  REQUIRE(entry);
+
+  REQUIRE(WriteOne(*entry, "some_data", kTimestamp) == Error::kOk);
+  REQUIRE(WriteOne(*entry, "some_data", kTimestamp) ==
+          Error{.code = 409, .message = "A record with timestamp 10100200 already exists"});
+}
+
 TEST_CASE("storage::Entry should create a new block if the current > max_block_size", "[entry]") {
   auto entry = IEntry::Build(kName, BuildTmpDirectory(), MakeDefaultOptions());
   REQUIRE(entry);


### PR DESCRIPTION
Closes #146

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Changes

### What is the current behavior?

Currently, a client can write records with the same timestamps. It causes duplication of timestamps. This is the reason why the querying doesn't work in (#146). To iterate data, the engine needs unique timestamps. 

### What is the new behavior?

The server returns 409 HTTP Error if a client tries to write a record with duplicated timestamp.

### Does this PR introduce a breaking change?** 

Possibly, but duplication of records anyway breaks the client code. 

### Other information:
