### PR TITLE
[#149] Stop waiting data from HTTP client if it aborts connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed:
 
 - Infinite loop in Bucket::KeepQuota, [PR-146](https://github.com/reduct-storage/reduct-storage/pull/146)
-
+- waiting data from HTTP client if it aborts
+  connection, [PR-151](https://github.com/reduct-storage/reduct-storage/pull/151)
 
 ## Changed:
 
@@ -27,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - Web Console v0.3.0, [PR-133](https://github.com/reduct-storage/reduct-storage/pull/133)
-- GET `/b/:bucket/:entry/q?` endpoint for iterating data, [PR-141](https://github.com/reduct-storage/reduct-storage/pull/141)
+- GET `/b/:bucket/:entry/q?` endpoint for iterating
+  data, [PR-141](https://github.com/reduct-storage/reduct-storage/pull/141)
 
 ### Changed:
 
@@ -196,18 +198,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release with basic HTTP API and FIFO bucket quota
 
 [Unreleased]: https://github.com/reduct-storage/reduct-storage/compare/v0.7.1...HEAD
+
 [0.7.1]: https://github.com/reduct-storage/reduct-storage/compare/v0.7.0...v0.7.1
+
 [0.7.0]: https://github.com/reduct-storage/reduct-storage/compare/v0.6.1...v0.7.0
+
 [0.6.1]: https://github.com/reduct-storage/reduct-storage/compare/v0.6.0...v0.6.1
+
 [0.6.0]: https://github.com/reduct-storage/reduct-storage/compare/v0.5.1...v0.6.0
+
 [0.5.1]: https://github.com/reduct-storage/reduct-storage/compare/v0.5.0...v0.5.1
+
 [0.5.0]: https://github.com/reduct-storage/reduct-storage/compare/v0.4.3...v0.5.0
+
 [0.4.3]: https://github.com/reduct-storage/reduct-storage/compare/v0.4.2...v0.4.3
+
 [0.4.2]: https://github.com/reduct-storage/reduct-storage/compare/v0.4.1...v0.4.2
+
 [0.4.1]: https://github.com/reduct-storage/reduct-storage/compare/v0.4.0...v0.4.1
+
 [0.4.0]: https://github.com/reduct-storage/reduct-storage/compare/v0.3.0...v0.4.0
+
 [0.3.0]: https://github.com/reduct-storage/reduct-storage/compare/v0.2.1...v0.3.0
+
 [0.2.1]: https://github.com/reduct-storage/reduct-storage/compare/v0.2.0...v0.2.1
+
 [0.2.0]: https://github.com/reduct-storage/reduct-storage/compare/v0.1.1...v0.2.0
+
 [0.1.1]: https://github.com/reduct-storage/reduct-storage/compare/v0.1.0...v0.1.1
+
 [0.1.0]: https://github.com/reduct-storage/reduct-storage/releases/tag/v0.1.0

--- a/src/reduct/api/api_server.cc
+++ b/src/reduct/api/api_server.cc
@@ -367,7 +367,7 @@ class ApiServer : public IApiServer {
       co_return;
     }
 
-    res->end({});
+    handler.Run({{}, Error::kOk});
     co_return;
   }
 
@@ -537,6 +537,7 @@ class ApiServer : public IApiServer {
         break;
       }
       case 404: {
+        // It's React.js paths
         ret = console_->Read("index.html");
         handler.Run(std::move(ret), replace_base_path);
         break;

--- a/src/reduct/api/common.h
+++ b/src/reduct/api/common.h
@@ -31,9 +31,14 @@ struct AsyncHttpReceiver {
   using Callback = uWS::MoveOnlyFunction<core::Error(std::string_view, bool)>;
   explicit AsyncHttpReceiver(uWS::HttpResponse<SSL> *res, Callback callback) : finish_{}, error_{}, res_(res) {
     res->onData([this, callback = std::move(callback)](std::string_view data, bool last) mutable {
-      LOG_TRACE("Received chuck {} kB", data.size() / 1024);
+      LOG_DEBUG("Received chuck {} kB", data.size() / 1024);
       error_ = callback(data, last);
       finish_ = last;
+    });
+
+    res->onAborted([this] {
+      LOG_ERROR("Aborted write operation");
+      error_ = core::Error{.code = 400};
     });
   }
 


### PR DESCRIPTION
Closes #149 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?
Bug Fix

### What is the current behavior?

If post request is aborted, AsyncReader continuous waiting for data infinitely and consume 100% CPU
 
### What is the new behavior?

Now, the reader uses callback OnAborted and stops wating.

### Does this PR introduce a breaking change?** 

Not

### Other information:
