### PR TITLE
[#150] Create a new block if current is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Fixed:
+### Fixed:
 
 - Infinite loop in Bucket::KeepQuota, [PR-146](https://github.com/reduct-storage/reduct-storage/pull/146)
 - waiting data from HTTP client if it aborts
   connection, [PR-151](https://github.com/reduct-storage/reduct-storage/pull/151)
 
-## Changed:
+### Changed:
 
-- Duplication of timestamps is not allowed, [PR147](https://github.com/reduct-storage/reduct-storage/pull/147)
+- Duplication of timestamps is not allowed, [PR-147](https://github.com/reduct-storage/reduct-storage/pull/147)
+
+### Fixed:
+
+- writing record when current block is broken, [PR-15-](https://github.com/reduct-storage/reduct-storage/pull/153)
 
 ## [0.7.1] - 2022-07-30
 

--- a/src/reduct/core/time.h
+++ b/src/reduct/core/time.h
@@ -7,5 +7,10 @@
 
 namespace reduct::core {
 using Time = std::chrono::system_clock::time_point;
+
+inline auto ToMicroseconds(Time tp) {
+  return std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()).count();
+}
+
 }
 #endif  // REDUCT_STORAGE_TIME_H

--- a/src/reduct/proto/storage/entry.proto
+++ b/src/reduct/proto/storage/entry.proto
@@ -10,6 +10,7 @@ message Record {
     kStarted = 0;     // has at least one chunk written
     kFinished = 1;    // finished without errors
     kErrored = 2;     // finished with error
+    kInvalid = 3;     // something wierd happened
   }
 
   message MetaEntry {
@@ -31,4 +32,5 @@ message Block {
   google.protobuf.Timestamp latest_record_time = 2;    // the timestamp of the latest record
   uint64 size = 3;                                // size of block in bytes (with protobuf overhead)
   repeated Record records = 4;                    // stored records
+  bool invalid = 5;                               // mark block as invalid if some IO happened
 }

--- a/src/reduct/storage/block_manager.cc
+++ b/src/reduct/storage/block_manager.cc
@@ -151,6 +151,10 @@ class BlockManager : public IBlockManager {
           if (auto err = SaveBlock(blk)) {
             LOG_ERROR("{}", err.ToString());
           }
+
+          if (state == proto::Record::kInvalid) {
+            blk->set_invalid(true);
+          }
         });
 
     auto& writers = RemoveDeadWriters(block);

--- a/src/reduct/storage/block_manager.cc
+++ b/src/reduct/storage/block_manager.cc
@@ -105,8 +105,6 @@ class BlockManager : public IBlockManager {
   }
 
   Error RemoveBlock(const BlockSPtr& block) override {
-    std::error_code ec;
-
     const auto& readers = RemoveDeadReaders(block);
     if (!readers.empty()) {
       return {.code = 500, .message = "Block has active readers"};
@@ -117,17 +115,27 @@ class BlockManager : public IBlockManager {
       return {.code = 500, .message = "Block has active writers"};
     }
 
-    fs::remove(BlockPath(parent_, *block), ec);
+    std::error_code ec;
+    auto path = BlockPath(parent_, *block);
+    auto make_error = [&ec, &path] {
+      return Error{.code = 500, .message = fmt::format("Failed to remove block {}: {}", path.string(), ec.message())};
+    };
+
+    // remove block with date
+    fs::remove(path, ec);
+    Error err;
     if (ec) {
-      return {.code = 500, .message = ec.message()};
+      err = make_error();
     }
 
-    fs::remove(BlockPath(parent_, *block, kMetaExt), ec);
+    // remove descriptor
+    path = BlockPath(parent_, *block, kMetaExt);
+    fs::remove(path, ec);
     if (ec) {
-      return {.code = 500, .message = ec.message()};
+      err = make_error();
     }
 
-    return Error::kOk;
+    return err;
   }
 
   core::Result<async::IAsyncReader::SPtr> BeginRead(const BlockSPtr& block, AsyncReaderParameters params) override {
@@ -147,13 +155,14 @@ class BlockManager : public IBlockManager {
             LOG_ERROR("{}", load_err.ToString());
             return;
           }
-          blk->mutable_records(index)->set_state(state);
-          if (auto err = SaveBlock(blk)) {
-            LOG_ERROR("{}", err.ToString());
-          }
 
+          blk->mutable_records(index)->set_state(state);
           if (state == proto::Record::kInvalid) {
             blk->set_invalid(true);
+          }
+
+          if (auto err = SaveBlock(blk)) {
+            LOG_ERROR("{}", err.ToString());
           }
         });
 

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -130,11 +130,10 @@ class Entry : public IEntry {
     auto has_no_space = block->size() + content_size > options_.max_block_size;
     auto too_many_records = block->records_size() + 1 > options_.max_block_records;
 
-    if (type == RecordType::kLatest && (has_no_space || too_many_records)) {
+    if (type == RecordType::kLatest && (has_no_space || too_many_records || block->invalid())) {
       LOG_DEBUG("Create a new block");
       if (auto err = block_manager_->FinishBlock(block)) {
-        LOG_ERROR("Failed to finish the current block");
-        return {{}, err};
+        LOG_WARNING("Failed to finish the current block: {}", err.ToString());
       }
 
       auto ret = start_new_block(proto_ts, content_size);

--- a/src/reduct/storage/io/async_writer.cc
+++ b/src/reduct/storage/io/async_writer.cc
@@ -33,7 +33,7 @@ class AsyncWriter : public async::IAsyncWriter {
   Error Write(std::string_view chunk, bool last) noexcept override {
     const auto& record = parameters_.record_index;
     if (!file_) {
-      update_record_(record, proto::Record::kErrored);
+      update_record_(record, proto::Record::kInvalid);
       return {.code = 500, .message = "Bad block"};
     }
 
@@ -44,7 +44,7 @@ class AsyncWriter : public async::IAsyncWriter {
     }
 
     if (!file_.write(chunk.data(), chunk.size())) {
-      update_record_(record, proto::Record::kErrored);
+      update_record_(record, proto::Record::kInvalid);
       return {.code = 500, .message = "Failed to write a chunk into a block"};
     }
 


### PR DESCRIPTION
Closes #150

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug Fix

### What is the current behavior?

If the current block is bad we never recover because the write operation doesn't finish properly to start a new one.
 
### What is the new behavior?

We mark a block as invalid if IO error happened and create a new one during the next write operation

### Does this PR introduce a breaking change?** 

Not

### Other information:
