### PR TITLE
[#148] Add `connection` to header and fix closing uSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 
 - Infinite loop in Bucket::KeepQuota, [PR-146](https://github.com/reduct-storage/reduct-storage/pull/146)
-- waiting data from HTTP client if it aborts
+- Waiting data from HTTP client if it aborts
   connection, [PR-151](https://github.com/reduct-storage/reduct-storage/pull/151)
+- Writing record when current block is broken, [PR-15-](https://github.com/reduct-storage/reduct-storage/pull/153)
 
 ### Changed:
 
 - Duplication of timestamps is not allowed, [PR-147](https://github.com/reduct-storage/reduct-storage/pull/147)
-
-### Fixed:
-
-- writing record when current block is broken, [PR-15-](https://github.com/reduct-storage/reduct-storage/pull/153)
 
 ## [0.7.1] - 2022-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- `Connection` header, [PR-154](https://github.com/reduct-storage/reduct-storage/pull/154)
+
 ### Fixed:
 
 - Infinite loop in Bucket::KeepQuota, [PR-146](https://github.com/reduct-storage/reduct-storage/pull/146)
 - Waiting data from HTTP client if it aborts
   connection, [PR-151](https://github.com/reduct-storage/reduct-storage/pull/151)
 - Writing record when current block is broken, [PR-15-](https://github.com/reduct-storage/reduct-storage/pull/153)
+- Closing uSocket, [PR-154](https://github.com/reduct-storage/reduct-storage/pull/154)
 
 ### Changed:
 


### PR DESCRIPTION
Closes #148 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

(You can also link to an open issue here)

### What is the new behavior?

We stopped server correctly only for unsecure HTTP. Also, we don't provide `connection` header.

### Does this PR introduce a breaking change?** 

Fix closing socket. If the server gets INT or TERM signals, it adds the header `Connection: close` for current HTTP requests. 

### Other information:
