### PR TITLE
Fix removing broken block when it keeps quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection, [PR-151](https://github.com/reduct-storage/reduct-storage/pull/151)
 - Writing record when current block is broken, [PR-15-](https://github.com/reduct-storage/reduct-storage/pull/153)
 - Closing uSocket, [PR-154](https://github.com/reduct-storage/reduct-storage/pull/154)
+- Removing broken block when it keeps quota, [PR-155](https://github.com/reduct-storage/reduct-storage/pull/155)
 
 ### Changed:
 

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -62,9 +62,9 @@ Content-length is required to start an asynchronous write operation
 {% swagger-description %}
 The method return a content of the requested record in the body of the HTTP response. It also sends additional information in headers:
 
-**-x-reduct-time** - UNIX timestamp of the record in microseconds
+**x-reduct-time** - UNIX timestamp of the record in microseconds
 
-**-x-reduct-last** - 1 - if a record is the last record in the query&#x20;
+**x-reduct-last** - 1 - if a record is the last record in the query&#x20;
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name=":bucket_name" required="true" %}

--- a/src/reduct/storage/block_manager.cc
+++ b/src/reduct/storage/block_manager.cc
@@ -121,11 +121,12 @@ class BlockManager : public IBlockManager {
       return Error{.code = 500, .message = fmt::format("Failed to remove block {}: {}", path.string(), ec.message())};
     };
 
-    // remove block with date
+    // remove block with data
     fs::remove(path, ec);
     Error err;
     if (ec) {
       err = make_error();
+      LOG_WARNING(err.ToString());
     }
 
     // remove descriptor
@@ -133,6 +134,7 @@ class BlockManager : public IBlockManager {
     fs::remove(path, ec);
     if (ec) {
       err = make_error();
+      LOG_WARNING(err.ToString());
     }
 
     return err;

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -414,8 +414,8 @@ class Entry : public IEntry {
 
     size_counter_ -= first_block->size();
     record_counter_ -= first_block->records_size();
-    block_set_.erase(first_block->begin_time());
-    return {};
+    block_set_.erase(block_set_.begin());
+    return Error::kOk;
   }
 
   [[nodiscard]] EntryInfo GetInfo() const override {


### PR DESCRIPTION

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

If we have a broken block with size 0, we have an infinite loop in Bucket::KeepQuota

### What is the new behavior?

We remove bad blocks at the start and if they appear we drop them during the keeping quota.

### Does this PR introduce a breaking change?** 

No

### Other information:
