### PR TITLE
Fix sending headers twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Writing record when current block is broken, [PR-15-](https://github.com/reduct-storage/reduct-storage/pull/153)
 - Closing uSocket, [PR-154](https://github.com/reduct-storage/reduct-storage/pull/154)
 - Removing broken block when it keeps quota, [PR-155](https://github.com/reduct-storage/reduct-storage/pull/155)
+- Sending headers twice, [PR-156](https://github.com/reduct-storage/reduct-storage/pull/156)
 
 ### Changed:
 

--- a/src/reduct/api/api_server.cc
+++ b/src/reduct/api/api_server.cc
@@ -481,7 +481,7 @@ class ApiServer : public IApiServer {
     LOG_DEBUG("Sent {} {}/{} kB", ts, ctx.res->getWriteOffset() / 1024, reader->size() / 1024);
 
 
-    handler.SendOk();
+    handler.SendOk("", true);
     co_return;
   }
 

--- a/src/reduct/api/common.h
+++ b/src/reduct/api/common.h
@@ -137,10 +137,11 @@ class BasicApiHandler {
     SendOk(on_success(std::move(resp)));
   }
 
-  void SendOk(std::string_view content = "") const noexcept {
+  void SendOk(std::string_view content = "", bool no_headers = false) const noexcept {
     LOG_DEBUG("{} {}: OK", method_, url_);
-    PrepareHeaders(!content.empty(), content_type_);
-
+    if (!no_headers) {
+      PrepareHeaders(!content.empty(), content_type_);
+    }
     http_resp_->end(std::move(content));
   }
 
@@ -161,7 +162,8 @@ class BasicApiHandler {
     headers_[header] = fmt::format("{}", value);
   }
 
-  void PrepareHeaders(bool has_content, std::string_view content_type = "") const {  // Allow CORS
+  void PrepareHeaders(bool has_content, std::string_view content_type = "") const {
+    // Allow CORS
     if (!origin_.empty()) {
       http_resp_->writeHeader("access-control-allow-origin", origin_);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

We send headers twice after the response in `GET /b/:bucket/:entry` method

### What is the new behavior?

We send headers once before sending the chunks of data

### Does this PR introduce a breaking change?** 

Not

### Other information:
