### PR TITLE
Add  to the docs after creating the build/ directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ sudo pip3 install conan
 After all the requirements are installed, you can build the storage:
 
 ```
-mkdir build
+mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j
 ```


### PR DESCRIPTION
Closes #157

### Please check if the PR fulfills these requirements

- [] Tests for the changes have been added (for bug fixes / features) -- NOT APPLICABLE
- [] Docs have been added / updated (for bug fixes / features) -- NOT APPLICABLE
- [] CHANGELOG.md have been updated (for bug fixes / features / docs) -- NOT APPLICABLE


### What kind of change does this PR introduce?

It just adds a step to `cd` into the `build/` directory after creating it while building the server.

### What is the current behavior?

There is no mention of `cd`ing into the directory. This is very obvious, but I just wanted to add it to the docs.

### What is the new behavior?

(if this is a feature change)


### Does this PR introduce a breaking change?** 

This PR does not introduce any breaking change.

### Other information:
No other information.