### PR TITLE
Added  to docs after creating the build/ dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
+- Direction to `cd` into the `build/` directory while building the server locally, [PR-159](https://github.com/reduct-storage/reduct-storage/pull/159)
 - `Connection` header, [PR-154](https://github.com/reduct-storage/reduct-storage/pull/154)
 
 ### Fixed:

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ sudo pip3 install conan
 After all the requirements are installed, you can build the storage:
 
 ```
-mkdir build
+mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j
 ```


### PR DESCRIPTION
Closes #157

### Please check if the PR fulfills these requirements

- [] Tests for the changes have been added (for bug fixes / features) -- NOT APPLICABLE
- [X] Docs have been added / updated (for bug fixes / features)
- [X] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

It just adds a step to `cd` into the `build/` directory after creating it while building the server.

### What is the current behavior?

There is no mention of `cd`ing into the directory. This is very obvious, but I just wanted to add it to the docs.

### What is the new behavior?

(if this is a feature change)


### Does this PR introduce a breaking change?** 

This PR does not introduce any breaking change.

### Other information:
No other information.