### PR TITLE
Fix update error bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 
+- Ignoring error code after a failed bucket update, [PR-161](https://github.com/reduct-storage/reduct-storage/pull/161)
 - Infinite loop in Bucket::KeepQuota, [PR-146](https://github.com/reduct-storage/reduct-storage/pull/146)
 - Waiting data from HTTP client if it aborts
   connection, [PR-151](https://github.com/reduct-storage/reduct-storage/pull/151)

--- a/src/reduct/storage/storage.cc
+++ b/src/reduct/storage/storage.cc
@@ -159,6 +159,10 @@ class Storage : public IStorage {
       }
 
       err = bucket_it->second->SetSettings(std::move(req.new_settings));
+      if (err) {
+        return Callback::Result{{}, err};
+      }
+
       return Callback::Result{{}, Error::kOk};
     });
   }

--- a/unit_tests/reduct/storage/storage_bucket_api_test.cc
+++ b/unit_tests/reduct/storage/storage_bucket_api_test.cc
@@ -136,7 +136,7 @@ TEST_CASE("storage::Storage should change settings of bucket", "[stoage]") {
         .new_settings = settings
     };
 
-    fs::remove(data_path / "bucket");
+    fs::remove_all(data_path / "bucket");
     auto result = OnChangeBucketSettings(storage.get(), change_req).Get();
     REQUIRE(result == Error{.code = 500, .message = "Failed to open file of bucket settings"});
   }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) -- NOT APPLICABLE
- [X] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?
This PR fixes #160 

### What is the current behavior?

If the underlying bucket directory is deleted without going through the delete bucket endpoint, the running process has no idea that the directory has been deleted. An update operation throws an error because it can't open the file, but this error is ignored and 200 OK is returned to the user by default.

### What is the new behavior?
The error is captured and returned back to the user appropriately.


### Does this PR introduce a breaking change?** 
No changes to the application is needed.

### Other information:
No other pertinent information.