### PR TITLE
Check bucket and entry name with regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor HTTP API layer, [PR-179](https://github.com/reduct-storage/reduct-storage/pull/179)
 
+### Security:
+
+- Check bucket and entry name with regex, [PR-181](https://github.com/reduct-storage/reduct-storage/pull/181)
+
 ## [0.9.0] - 2022-09-18
 
 ### Added:

--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04 AS builder
 
 RUN apt update && apt install -y cmake python3-pip zip
 
-RUN pip3 install conan==1.51.3
+RUN pip3 install conan~=1.52.0
 
 WORKDIR /src
 

--- a/src/reduct/storage/bucket.cc
+++ b/src/reduct/storage/bucket.cc
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <numeric>
 #include <ranges>
+#include <regex>
 
 #include "reduct/config.h"
 #include "reduct/core/logger.h"
@@ -73,6 +74,10 @@ class Bucket : public IBucket {
   core::Result<IEntry::WPtr> GetOrCreateEntry(const std::string& name) override {
     if (name.empty()) {
       return {{}, {.code = 422, .message = "An empty entry name is not allowed"}};
+    }
+
+    if (!std::regex_match(name, std::regex("^[A-Za-z0-9_-]*$"))) {
+      return {{}, Error{.code = 422, .message = "Entry name can contain only letters, digests and [-,_] symbols"}};
     }
 
     auto it = entry_map_.find(name);

--- a/src/reduct/storage/storage.cc
+++ b/src/reduct/storage/storage.cc
@@ -2,6 +2,7 @@
 #include "reduct/storage/storage.h"
 
 #include <filesystem>
+#include <regex>
 #include <utility>
 
 #include "reduct/config.h"
@@ -85,6 +86,12 @@ class Storage : public IStorage {
    * Bucket API
    */
   core::Error CreateBucket(const std::string& bucket_name, const proto::api::BucketSettings& settings) override {
+    if (!std::regex_match(bucket_name, std::regex("^[A-Za-z0-9_-]*$"))) {
+      return Error{
+          .code = 422,
+          .message = "Bucket name can contain only letters, digests and [-,_] symbols"};
+    }
+
     if (buckets_.find(bucket_name) != buckets_.end()) {
       return Error{.code = 409, .message = fmt::format("Bucket '{}' already exists", bucket_name)};
     }

--- a/unit_tests/reduct/storage/bucket_test.cc
+++ b/unit_tests/reduct/storage/bucket_test.cc
@@ -80,6 +80,11 @@ TEST_CASE("storage::Bucket should create get or create entry", "[bucket][entry]"
     REQUIRE(ref.error == Error::kOk);
     REQUIRE(ref.result.lock()->GetInfo().record_count() == 1);
   }
+
+  SECTION("wrong entry name") {
+    auto [_, err] = bucket->GetOrCreateEntry("entry/sak#");
+    REQUIRE(err == Error{.code = 422, .message = "Entry name can contain only letters, digests and [-,_] symbols"});
+  }
 }
 
 TEST_CASE("storage::Bucket should remove all entries", "[bucket]") {

--- a/unit_tests/reduct/storage/storage_test.cc
+++ b/unit_tests/reduct/storage/storage_test.cc
@@ -117,6 +117,11 @@ TEST_CASE("storage::Storage should create a bucket", "[storage]") {
     auto err = storage->CreateBucket("", MakeDefaultBucketSettings());
     REQUIRE(err == Error{.code = 500, .message = "Internal error: Failed to create bucket"});
   }
+
+  SECTION("wrong name") {
+    auto err = storage->CreateBucket("bucket/sak#", MakeDefaultBucketSettings());
+    REQUIRE(err == Error{.code = 422, .message = "Bucket name can contain only letters, digests and [-,_] symbols"});
+  }
 }
 
 TEST_CASE("storage::Storage should get a bucket", "[storage]") {


### PR DESCRIPTION
Closes #180

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Security update

### What is the current behavior?

We don't check bucket and entry name, which can be used to write something out of the storage folder

### What is the new behavior?

To create path-like buckets or entries, is impossible.

### Does this PR introduce a breaking change?

No

### Other information:
