### PR TITLE
Add prefix `/api/v1/` for all endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - Refactor HTTP API layer, [PR-179](https://github.com/reduct-storage/reduct-storage/pull/179)
+- Prefix `/api/v1/` for all endpoints, [PR-182](https://github.com/reduct-storage/reduct-storage/pull/182)
 
 ### Security:
 
@@ -24,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- Build a static executable for AMD64 and upload it to release from CI, [PR-171](https://github.com/reduct-storage/reduct-storage/pull/171)
+- Build a static executable for AMD64 and upload it to release from
+  CI, [PR-171](https://github.com/reduct-storage/reduct-storage/pull/171)
 - Build on MacOS, [PR-173](https://github.com/reduct-storage/reduct-storage/pull/173)
 - Build on Windows, [PR-174](https://github.com/reduct-storage/reduct-storage/pull/174)
 
@@ -51,9 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closing uSocket, [PR-154](https://github.com/reduct-storage/reduct-storage/pull/154)
 - Removing broken block when it keeps quota, [PR-155](https://github.com/reduct-storage/reduct-storage/pull/155)
 - Sending headers twice, [PR-156](https://github.com/reduct-storage/reduct-storage/pull/156)
-- Direction to `cd` into the `build/` directory while building the server locally, [PR-159](https://github.com/reduct-storage/reduct-storage/pull/159)
+- Direction to `cd` into the `build/` directory while building the server
+  locally, [PR-159](https://github.com/reduct-storage/reduct-storage/pull/159)
 
 ### Changed:
+
 - Duplication of timestamps is not allowed, [PR-147](https://github.com/reduct-storage/reduct-storage/pull/147)
 - Update dependencies, [PR-163](https://github.com/reduct-storage/reduct-storage/pull/163)
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ export API_TOKEN=reduct
 curl -d "{\"quota_type\":\"FIFO\", \"quota_size\":10000}" \
   -X POST \
   --header "Authorization: Bearer ${API_TOKEN}"   \
-  -a https://play.reduct-storage.dev/b/my_data
+  -a https://play.reduct-storage.dev/api/v1/b/my_data
 
 # Write some data
 curl -d "some_data" \
   -X POST \
   --header "Authorization: Bearer ${API_TOKEN}"   \
-  -a https://play.reduct-storage.dev/b/my_data/entry_1?ts=10000
+  -a https://play.reduct-storage.dev/api/v1/b/my_data/entry_1?ts=10000
 
 # Read the data by using its timestamp
 curl --header "Authorization: Bearer ${API_TOKEN}"   \
-    https://play.reduct-storage.dev/b/my_data/entry_1?ts=10000
+    https://play.reduct-storage.dev/api/v1/b/my_data/entry_1?ts=10000
 ```
 
 ##  Client SDKs

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -8,7 +8,7 @@ import requests
 
 @pytest.fixture(name="base_url")
 def _base_url() -> str:
-    return f"{os.getenv('STORAGE_URL', 'http://127.0.0.1:8383/api/v1')}"
+    return f"{os.getenv('STORAGE_URL', 'http://127.0.0.1:8383')}/api/v1"
 
 
 @pytest.fixture(name='bucket_name')

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -8,7 +8,7 @@ import requests
 
 @pytest.fixture(name="base_url")
 def _base_url() -> str:
-    return f"{os.getenv('STORAGE_URL', 'http://127.0.0.1:8383')}"
+    return f"{os.getenv('STORAGE_URL', 'http://127.0.0.1:8383/api/v1')}"
 
 
 @pytest.fixture(name='bucket_name')

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,13 +11,13 @@ The current version supports Linux OS, MacOS and was tested on an AMD64 platform
 The easiest way to start using Reduct Storage is to run Docker image:
 
 ```
-docker run -p 8383:8383 -v ${PWD}/data:/data reductstorage/engine:latest 
+docker run -p 8383:8383 -v ${PWD}/data:/data reductstorage/engine:latest
 ```
 
 The storage will be available on port http://127.0.01:8383 and stores data in the `./data` directory. You may check if it's working with a simple HTTP request:
 
 ```
-curl http://127.0.0.1:8383/info
+curl http://127.0.0.1:8383/api/v1/info
 ```
 
 ### Build Manually

--- a/docs/http-api/bucket-api.md
+++ b/docs/http-api/bucket-api.md
@@ -15,7 +15,7 @@ For more information, you can read more about buckets in [How does it work?](../
 
 
 
-{% swagger method="get" path=" " baseUrl="/b/:bucket_name " summary="Get information about a bucket" %}
+{% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Get information about a bucket" %}
 {% swagger-description %}
 The method returns the current settings, stats, and entry list of the bucket in JSON format.
 {% endswagger-description %}
@@ -64,7 +64,7 @@ Name of bucket
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="head" path=" " baseUrl="/b/:bucket_name " summary="Check if a bucket exists" %}
+{% swagger method="head" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Check if a bucket exists" %}
 {% swagger-description %}
 
 {% endswagger-description %}
@@ -90,7 +90,7 @@ Name of bucket
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="post" path=" " baseUrl="/b/:bucket_name  " summary="Create a new bucket" %}
+{% swagger method="post" path=" " baseUrl="/api/v1/b/:bucket_name  " summary="Create a new bucket" %}
 {% swagger-description %}
 To create a bucket, the request should contain a JSON document with some parameters or empty body. The new bucket uses default values if some parameters are empty:
 {% endswagger-description %}
@@ -140,7 +140,7 @@ Size of quota in bytes (default: 0)
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="put" path=" " baseUrl="/b/:bucket_name " summary="Change settings of a bucket" %}
+{% swagger method="put" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Change settings of a bucket" %}
 {% swagger-description %}
 To update settings of a bucket, the request should have a JSON document with all the settings
 {% endswagger-description %}
@@ -190,7 +190,7 @@ Size of quota in bytes
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="delete" path=" " baseUrl="/b/:bucket_name " summary="Remove a bucket" %}
+{% swagger method="delete" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Remove a bucket" %}
 {% swagger-description %}
 Remove a bucket with
 

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -4,7 +4,7 @@ description: Entry API provides methods to write, read and browse the data
 
 # Entry API
 
-{% swagger method="post" path=" " baseUrl="/b/:bucket_name/:entry_name" summary="Write a record to an entry" %}
+{% swagger method="post" path=" " baseUrl="/api/v1/b/:bucket_name/:entry_name" summary="Write a record to an entry" %}
 {% swagger-description %}
 The storage creates an entry on the first write operation. The record should be placed in the body of the request. The body can also be empty.
 {% endswagger-description %}
@@ -58,7 +58,7 @@ Content-length is required to start an asynchronous write operation
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="get" path=" " baseUrl="/b/:bucket_name/:entry_name " summary="Get a record from an entry" %}
+{% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name/:entry_name " summary="Get a record from an entry" %}
 {% swagger-description %}
 The method return a content of the requested record in the body of the HTTP response. It also sends additional information in headers:
 
@@ -110,7 +110,7 @@ A UNIX timestamp in microseconds. If it is empty, the latest record is returned.
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="get" path="" baseUrl="/b/:bucket_name/:entry_name/q " summary="Query records for a time interval" %}
+{% swagger method="get" path="" baseUrl="/api/v1/b/:bucket_name/:entry_name/q " summary="Query records for a time interval" %}
 {% swagger-description %}
 The method response with a JSON document with ID which can be used to integrate records with method
 

--- a/docs/http-api/server-api.md
+++ b/docs/http-api/server-api.md
@@ -4,7 +4,7 @@ description: Server API provides information about the storage and its state
 
 # Server API
 
-{% swagger method="get" path=" " baseUrl="/info" summary="Get statistical information about the storage" %}
+{% swagger method="get" path=" " baseUrl="/api/v1/info" summary="Get statistical information about the storage" %}
 {% swagger-description %}
 You can use this method to get stats of the storage and check its version.
 {% endswagger-description %}
@@ -30,7 +30,7 @@ You can use this method to get stats of the storage and check its version.
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="get" path=" " baseUrl="/list" summary="Get a list of the buckets with their stats" %}
+{% swagger method="get" path=" " baseUrl="/api/v1/list" summary="Get a list of the buckets with their stats" %}
 {% swagger-description %}
 You can use this method to browse the buckets of the storage.
 {% endswagger-description %}
@@ -53,7 +53,7 @@ You can use this method to browse the buckets of the storage.
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="head" path=" " baseUrl="/alive " summary="Check if the storage engine is working" %}
+{% swagger method="head" path=" " baseUrl="/api/v1/alive " summary="Check if the storage engine is working" %}
 {% swagger-description %}
 You can use this method for health checks in Docker or Kubernetes environment
 {% endswagger-description %}

--- a/docs/http-api/token-authentication.md
+++ b/docs/http-api/token-authentication.md
@@ -17,7 +17,7 @@ Bearer <ACCESS_TOKEN>
 An example of a request with CURL:
 
 ```shell
- curl   --header "Authorization: Bearer ${API_TOKEN}" -a http://127.0.0.1:8383/info
+ curl   --header "Authorization: Bearer ${API_TOKEN}" -a http://127.0.0.1:8383/api/v1/info
 ```
 
 {% hint style="info" %}

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -223,67 +223,69 @@ class HttpServer : public IHttpServer {
     if (!base_path.ends_with('/')) {
       base_path.push_back('/');
     }
+
+    const auto api_path = base_path + "api/v1/";
     // Server API
-    app.head(base_path + "alive",
+    app.head(api_path + "alive",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running},
                                 [this]() { return ServerApi::Alive(storage_.get()); });
              })
-        .get(base_path + "info",
+        .get(api_path + "info",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running},
                                 [this]() { return ServerApi::Info(storage_.get()); });
              })
-        .get(base_path + "list",
+        .get(api_path + "list",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running},
                                 [this]() { return ServerApi::List(storage_.get()); });
              })
         // Bucket API
-        .post(base_path + "b/:bucket_name",
+        .post(api_path + "b/:bucket_name",
               [this, running](auto *res, auto *req) {
                 RegisterEndpoint(HttpContext<SSL>{res, req, running}, [this, req]() {
                   return BucketApi::CreateBucket(storage_.get(), req->getParameter(0));
                 });
               })
-        .get(base_path + "b/:bucket_name",
+        .get(api_path + "b/:bucket_name",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running},
                                 [this, req]() { return BucketApi::GetBucket(storage_.get(), req->getParameter(0)); });
              })
-        .head(base_path + "b/:bucket_name",
+        .head(api_path + "b/:bucket_name",
               [this, running](auto *res, auto *req) {
                 RegisterEndpoint(HttpContext<SSL>{res, req, running},
                                  [this, req]() { return BucketApi::HeadBucket(storage_.get(), req->getParameter(0)); });
               })
-        .put(base_path + "b/:bucket_name",
+        .put(api_path + "b/:bucket_name",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running}, [this, req]() {
                  return BucketApi::UpdateBucket(storage_.get(), req->getParameter(0));
                });
              })
-        .del(base_path + "b/:bucket_name",
+        .del(api_path + "b/:bucket_name",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running}, [this, req]() {
                  return BucketApi::RemoveBucket(storage_.get(), req->getParameter(0));
                });
              })
         // Entry API
-        .post(base_path + "b/:bucket_name/:entry_name",
+        .post(api_path + "b/:bucket_name/:entry_name",
               [this, running](auto *res, auto *req) {
                 RegisterEndpoint(HttpContext<SSL>{res, req, running}, [this, req]() {
                   return EntryApi::Write(storage_.get(), req->getParameter(0), req->getParameter(1),
                                          req->getQuery("ts"), req->getHeader("content-length"));
                 });
               })
-        .get(base_path + "b/:bucket_name/:entry_name",
+        .get(api_path + "b/:bucket_name/:entry_name",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running}, [this, req]() {
                  return EntryApi::Read(storage_.get(), req->getParameter(0), req->getParameter(1), req->getQuery("ts"),
                                        req->getQuery("q"));
                });
              })
-        .get(base_path + "b/:bucket_name/:entry_name/q",
+        .get(api_path + "b/:bucket_name/:entry_name/q",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(HttpContext<SSL>{res, req, running}, [this, req]() {
                  return EntryApi::Query(storage_.get(), std::string(req->getParameter(0)),


### PR DESCRIPTION
Closes #135

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

See #135

### What is the new behavior?

We have `/api/v1/` prefixes for all API endpoints

### Does this PR introduce a breaking change?

Yes

### Other information:
