### PR TITLE
Fix parsing endpoint url to print it in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 
 - Build MacOs in pipeline, [PR-188](https://github.com/reduct-storage/reduct-storage/pull/188)
+- Fix parsing endpoint url to print it in logs, [PR-190](https://github.com/reduct-storage/reduct-storage/pull/190)
 
 ## [1.0.0] - 2022-10-03
 

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -112,7 +112,7 @@ class HttpServer : public IHttpServer {
   template <bool SSL>
   VoidTask RegisterEndpoint(HttpContext<SSL> ctx, HttpResponseHandler &&handler) const {
     std::string method(ctx.req->getMethod());
-    auto url = ctx.req->getUrl();
+    std::string url{ctx.req->getUrl()};
     auto authorization = ctx.req->getHeader("authorization");
     auto origin = ctx.req->getHeader("origin");
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

We print endpoints URLs in debug mode, we use a string view from uWebScokets. It's wrong because they may be destroyed before we print them.

### What is the new behavior?

Save the URL in a string.


### Does this PR introduce a breaking change?

No

### Other information:
