### PR TITLE
No error body for HEAD /b/:bucket_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 
-- Fix link to Entry API in documentation, [PR-194](https://github.com/reduct-storage/reduct-storage/pull/194)
+- Link to Entry API in documentation, [PR-194](https://github.com/reduct-storage/reduct-storage/pull/194)
+- No error body for HEAD `/b/:bucket_name`, [PR-196](https://github.com/reduct-storage/reduct-storage/pull/196)
 
 ## [1.0.1] - 2022-10-09
 

--- a/src/reduct/api/bucket_api.cc
+++ b/src/reduct/api/bucket_api.cc
@@ -36,6 +36,7 @@ Result<HttpResponse> BucketApi::GetBucket(const IStorage* storage, std::string_v
 core::Result<HttpResponse> BucketApi::HeadBucket(const storage::IStorage* storage, std::string_view name) {
   auto [bucket_ptr, err] = storage->GetBucket(std::string(name));
   if (err) {
+    err.message = "";
     return {{}, err};
   }
 

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -139,7 +139,11 @@ class HttpServer : public IHttpServer {
       ctx.res->writeStatus(std::to_string(err.code));
       CommonHeaders();
       ctx.res->writeHeader("content-type", "application/json");
-      ctx.res->end(fmt::format(R"({{"detail":"{}"}})", err.message));
+      if (err.message.empty()) {
+        ctx.res->end({});
+      } else {
+        ctx.res->end(fmt::format(R"({{"detail":"{}"}})", err.message));
+      }
     };
 
     if (!ctx.no_auth) {

--- a/unit_tests/reduct/api/bucket_api_test.cc
+++ b/unit_tests/reduct/api/bucket_api_test.cc
@@ -87,7 +87,7 @@ TEST_CASE("BucketApi::HeadBucket should get a bucket") {
 
   SECTION("doesn't exist") {
     auto [resp, err] = BucketApi::HeadBucket(storage.get(), "bucket");
-    REQUIRE(err == Error{.code = 404, .message = "Bucket 'bucket' is not found"});
+    REQUIRE(err == Error{.code = 404, .message = ""});
   }
 }
 


### PR DESCRIPTION
Closes #195 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #195 

### What is the new behavior?

HEAD request doesn't return a body even for an error


### Does this PR introduce a breaking change?

No

### Other information:
