### PR TITLE
Fix: Use GET /tokens instead of /tokens/list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Link to Entry API in documentation, [PR-194](https://github.com/reduct-storage/reduct-storage/pull/194)
 - No error body for HEAD `/b/:bucket_name`, [PR-196](https://github.com/reduct-storage/reduct-storage/pull/196)
+- Use `GET /tokens` instead of `/tokens/list`, [PR-200](https://github.com/reduct-storage/reduct-storage/pull/200)
 
 ## [1.0.1] - 2022-10-09
 

--- a/api_tests/token_api_test.py
+++ b/api_tests/token_api_test.py
@@ -49,7 +49,7 @@ def test__list_tokens(base_url, session, token_name):
     resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions)
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/tokens/list')
+    resp = session.get(f'{base_url}/tokens')
     assert resp.status_code == 200
     assert resp.headers['content-type'] == "application/json"
     assert token_name in [t["name"] for t in json.loads(resp.content)["tokens"]]
@@ -58,10 +58,10 @@ def test__list_tokens(base_url, session, token_name):
 @requires_env("API_TOKEN")
 def test__list_token_with_full_access(base_url, session, token_without_permissions):
     """Needs full access to list tokens"""
-    resp = session.get(f'{base_url}/tokens/list', headers=auth_headers(''))
+    resp = session.get(f'{base_url}/tokens', headers=auth_headers(''))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/tokens/list', headers=auth_headers(token_without_permissions))
+    resp = session.get(f'{base_url}/tokens', headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
     assert get_detail(resp) == "Token doesn't have full access"
 
@@ -117,7 +117,7 @@ def test__delete_token(base_url, session, token_name):
     resp = session.delete(f'{base_url}/tokens/{token_name}')
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/tokens/list')
+    resp = session.get(f'{base_url}/tokens')
     assert resp.status_code == 200
     assert token_name not in [t["name"] for t in json.loads(resp.content)["tokens"]]
 

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -324,7 +324,7 @@ class HttpServer : public IHttpServer {
                    });
              })
         // Token API
-        .get(api_path + "tokens/list",
+        .get(api_path + "tokens",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(FullAccess(), HttpContext<SSL>{res, req, running},
                                 [this]() { return TokenApi::ListTokens(token_repository_.get()); });


### PR DESCRIPTION


### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Fix

### What is the current behavior?

To take list of tokens, we have `GET /tokens/list` endpoints. If a user creates a token called `list`, it may have a conflict. 

### What is the new behavior?

We use `GET /tokens` to avoid this issue.


### Does this PR introduce a breaking change?

No

### Other information:
