### PR TITLE
Always override init-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No error body for HEAD `/b/:bucket_name`, [PR-196](https://github.com/reduct-storage/reduct-storage/pull/196)
 - Use `GET /tokens` instead of `/tokens/list`, [PR-200](https://github.com/reduct-storage/reduct-storage/pull/200)
 
+### Changed:
+
+- Always override init-token, [PR-201](https://github.com/reduct-storage/reduct-storage/pull/201)
+
 ## [1.0.1] - 2022-10-09
 
 ### Added:

--- a/src/reduct/auth/token_repository.cc
+++ b/src/reduct/auth/token_repository.cc
@@ -41,13 +41,7 @@ class TokenRepository : public ITokenRepository {
 
     if (!options.api_token.empty()) {
       const auto kInitTokenName = "init-token";
-      auto v = repo_ | std::views::values |
-               std::views::filter([&options](auto t) { return t.value() == options.api_token; });
-      if (!v.empty()) {
-        return;
-      }
 
-      LOG_DEBUG("Create '{}' token", kInitTokenName);
       Token token;
       token.set_name(kInitTokenName);
       token.set_value(std::string(options.api_token));
@@ -55,10 +49,6 @@ class TokenRepository : public ITokenRepository {
 
       token.mutable_permissions()->set_full_access(true);
       repo_[kInitTokenName] = token;
-
-      if (auto err = SaveRepo()) {
-        LOG_ERROR("Failed to save '{}': {}", kInitTokenName, err);
-      }
     }
   }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

The storage engine check if `init-token` is stored in `.auth` file before override.  It isn't necessary, we can just override it all the time because a user can't change it.

### What is the new behavior?

We force `init-token` during the start


### Does this PR introduce a breaking change?

No

### Other information:
