### PR TITLE
Stop handle input chunks after an HTTP error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A crush when we handle input chunks after an HTTP
+  error, [PR-206](https://github.com/reduct-storage/reduct-storage/pull/206)
+
 ## [1.1.0] - 2022-11-27
 
 ### Added:

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -146,6 +146,20 @@ def test_read_write_big_blob(base_url, session, bucket):
     assert resp.text == blob
 
 
+def test_write_big_blob_with_error(base_url, session, bucket):
+    """Should write a big blob with error and don't crush"""
+    blob = np.random.bytes(2 ** 20).hex()
+    ts = 1000
+
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data=blob)
+    assert resp.status_code == 200
+
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data=blob)
+    assert resp.status_code == 409
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry')
+    assert resp.status_code == 200
+
 @requires_env("API_TOKEN")
 def test__write_with_write_token(base_url, session, bucket, token_without_permissions, token_read_bucket,
                                  token_write_bucket):

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -96,6 +96,7 @@ class HttpServer : public IHttpServer {
 
     void await_suspend(std::coroutine_handle<> h) const noexcept {
       if (finish_ || error_) {
+        res_->onData([](auto, bool) {});
         h.resume();
       } else {
         async::ILoop::loop().Defer([this, h] { await_suspend(h); });


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

We may crush when we have a record for writing but we return an HTTP error.

### What is the new behavior?

If we have an HTTP error, we stop handling input chunks


### Does this PR introduce a breaking change?

No

### Other information:
