### PR TITLE
Add `GET /api/v1/me`entpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- `GET /api/v1/me` endpoint to get current
+  permissions, [PR-202](https://github.com/reduct-storage/reduct-storage/pull/208)
+
 ### Changed:
 
 - Consistent token and bucket management, [PR-208](https://github.com/reduct-storage/reduct-storage/pull/208)

--- a/api_tests/server_api_test.py
+++ b/api_tests/server_api_test.py
@@ -89,3 +89,6 @@ def test__me(base_url, session, ):
     data = json.loads(resp.content)
     assert data['name'] == 'init-token'
     assert data['permissions'] == {'full_access': True, 'read': [], 'write': []}
+
+    resp = session.get(f'{base_url}/me', headers=auth_headers(''))
+    assert resp.status_code == 401

--- a/api_tests/server_api_test.py
+++ b/api_tests/server_api_test.py
@@ -78,3 +78,14 @@ def test__anonymous_alive(base_url, session):
     """should access /alive without token"""
     resp = session.head(f'{base_url}/alive', headers={})
     assert resp.status_code == 200
+
+
+@requires_env("API_TOKEN")
+def test__me(base_url, session, ):
+    """Should provide information about current token"""
+    resp = session.get(f'{base_url}/me')
+
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert data['name'] == 'init-token'
+    assert data['permissions'] == {'full_access': True, 'read': [], 'write': []}

--- a/docs/http-api/server-api.md
+++ b/docs/http-api/server-api.md
@@ -40,8 +40,6 @@ You can use this method to get stats of the storage and check its version. If au
 {% endswagger-response %}
 {% endswagger %}
 
-
-
 {% swagger method="get" path=" " baseUrl="/api/v1/list" summary="Get a list of the buckets with their stats" %}
 {% swagger-description %}
 You can use this method to browse the buckets of the storage. If authenticaion is enabled, the method needs a valid API token.
@@ -75,8 +73,6 @@ You can use this method to browse the buckets of the storage. If authenticaion i
 {% endswagger-response %}
 {% endswagger %}
 
-
-
 {% swagger method="head" path=" " baseUrl="/api/v1/alive " summary="Check if the storage engine is working" %}
 {% swagger-description %}
 You can use this method for health checks in Docker or Kubernetes environment. The method has anonymous access.
@@ -93,3 +89,30 @@ You can use this method for health checks in Docker or Kubernetes environment. T
 {% endswagger-response %}
 {% endswagger %}
 
+{% swagger method="get" path="" baseUrl="/api/v1/me" summary="Get full information about current API token" %}
+{% swagger-description %}
+This method takes a token from the Authentication header and returns its name, permissions and additional information
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="Returns JSON document" %}
+```javascript
+{
+    "name": "stirng",            // unique name of topic
+    "created_at": "string"       // creation date as ISO string
+    "permission": {
+        "full_access": "bool",
+        "read": []               // list of bucket names for read access
+        "write": []              // list of bucket names for write access
+    }
+}
+```
+{% endswagger-response %}
+
+{% swagger-response status="401: Unauthorized" description="API token is invalid" %}
+```javascript
+{
+    "detail": "error message"
+}
+```
+{% endswagger-response %}
+{% endswagger %}

--- a/src/reduct/api/common.h
+++ b/src/reduct/api/common.h
@@ -63,8 +63,7 @@ std::string PrintToJson(T &&msg) {
 }
 
 /**
- * Default receiver which does nothing but generate a response with error code
- * @param error
+ * Default receiver which does nothing but generate a response
  * @return
  */
 static core::Result<HttpRequestReceiver> DefaultReceiver(core::Error error = core::Error::kOk) {

--- a/src/reduct/api/console.cc
+++ b/src/reduct/api/console.cc
@@ -29,7 +29,7 @@ Result<HttpRequestReceiver> Console::UiRequest(const asset::IAssetManager* conso
         break;
       }
       default: {
-        return DefaultReceiver(ret.error);
+        return ret.error;
       }
     }
 

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -373,7 +373,7 @@ class HttpServer : public IHttpServer {
         .any("/*",
              [this, running](auto *res, auto *req) {
                RegisterEndpoint(Anonymous(), HttpContext<SSL>{res, req, running},
-                                []() -> Result<HttpRequestReceiver> { return DefaultReceiver(Error::NotFound()); });
+                                []() -> Result<HttpRequestReceiver> { return Error::NotFound(); });
              })
         .listen(host, port, 0,
                 [&](us_listen_socket_t *sock) {

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -261,6 +261,12 @@ class HttpServer : public IHttpServer {
                RegisterEndpoint(Authenticated(), HttpContext<SSL>{res, req, running},
                                 [this]() { return ServerApi::List(storage_.get()); });
              })
+        .get(api_path + "me",
+             [this, running](auto *res, auto *req) {
+               RegisterEndpoint(Authenticated(), HttpContext<SSL>{res, req, running}, [this, req]() {
+                 return ServerApi::Me(token_repository_.get(), req->getHeader("authorization"));
+               });
+             })
         // Bucket API
         .post(api_path + "b/:bucket_name",
               [this, running](auto *res, auto *req) {

--- a/src/reduct/api/server_api.cc
+++ b/src/reduct/api/server_api.cc
@@ -12,7 +12,7 @@ using core::Error;
 using core::Result;
 using storage::IStorage;
 
-Result<HttpRequestReceiver> ServerApi::Alive(const IStorage* storage) { return DefaultReceiver(Error::kOk); }
+Result<HttpRequestReceiver> ServerApi::Alive(const IStorage* storage) { return DefaultReceiver(); }
 
 Result<HttpRequestReceiver> ServerApi::Info(const IStorage* storage) { return SendJson(storage->GetInfo()); }
 
@@ -21,11 +21,11 @@ Result<HttpRequestReceiver> ServerApi::List(const IStorage* storage) { return Se
 core::Result<HttpRequestReceiver> ServerApi::Me(const auth::ITokenRepository* token_repo,
                                                 std::string_view auth_header) {
   auto [token_value, error] = ParseBearerToken(auth_header);
-  if (error != Error::kOk) {
-    return DefaultReceiver(error);
+  if (error) {
+    return error;
   }
 
-  return SendJson(token_repo->FindByName(token_value));
+  return SendJson(token_repo->ValidateToken(token_value));
 }
 
 }  // namespace reduct::api

--- a/src/reduct/api/server_api.cc
+++ b/src/reduct/api/server_api.cc
@@ -2,18 +2,30 @@
 
 #include "reduct/api/server_api.h"
 
+#include "reduct/auth/token_auth.h"
+
 namespace reduct::api {
 
+using auth::ITokenRepository;
+using auth::ParseBearerToken;
 using core::Error;
 using core::Result;
 using storage::IStorage;
 
-Result<HttpRequestReceiver> ServerApi::Alive(const IStorage* storage) {
-  return DefaultReceiver(Error::kOk);
-}
+Result<HttpRequestReceiver> ServerApi::Alive(const IStorage* storage) { return DefaultReceiver(Error::kOk); }
 
 Result<HttpRequestReceiver> ServerApi::Info(const IStorage* storage) { return SendJson(storage->GetInfo()); }
 
 Result<HttpRequestReceiver> ServerApi::List(const IStorage* storage) { return SendJson(storage->GetList()); }
+
+core::Result<HttpRequestReceiver> ServerApi::Me(const auth::ITokenRepository* token_repo,
+                                                std::string_view auth_header) {
+  auto [token_value, error] = ParseBearerToken(auth_header);
+  if (error != Error::kOk) {
+    return DefaultReceiver(error);
+  }
+
+  return SendJson(token_repo->FindByName(token_value));
+}
 
 }  // namespace reduct::api

--- a/src/reduct/api/server_api.h
+++ b/src/reduct/api/server_api.h
@@ -5,6 +5,7 @@
 
 #include "reduct/api/common.h"
 #include "reduct/storage/storage.h"
+#include "reduct/auth/token_repository.h"
 
 namespace reduct::api {
 
@@ -24,6 +25,11 @@ class ServerApi {
    * GET /list
    */
   static core::Result<HttpRequestReceiver> List(const storage::IStorage* storage);
+
+  /**
+   * GET /me
+   */
+  static core::Result<HttpRequestReceiver> Me(const auth::ITokenRepository* token_repo, std::string_view auth_header);
 };
 
 }  // namespace reduct::api

--- a/src/reduct/api/token_api.cc
+++ b/src/reduct/api/token_api.cc
@@ -40,7 +40,7 @@ Result<HttpRequestReceiver> TokenApi::CreateToken(ITokenRepository* repository, 
 Result<HttpRequestReceiver> TokenApi::ListTokens(ITokenRepository* repository) {
   auto [list, err] = repository->GetTokenList();
   if (err) {
-    return DefaultReceiver(err);
+    return err;
   }
 
   proto::api::TokenRepo response;
@@ -54,13 +54,16 @@ Result<HttpRequestReceiver> TokenApi::ListTokens(ITokenRepository* repository) {
 Result<HttpRequestReceiver> TokenApi::GetToken(auth::ITokenRepository* repository, std::string_view name) {
   auto [token, err] = repository->FindByName(std::string(name));
   if (err) {
-    return DefaultReceiver(err);
+    return err;
   }
 
   return SendJson<proto::api::Token>({std::move(token), Error::kOk});
 }
 core::Result<HttpRequestReceiver> TokenApi::RemoveToken(auth::ITokenRepository* repository, std::string_view name) {
   auto err = repository->RemoveToken(std::string(name));
-  return DefaultReceiver(err);
+  if (err) {
+    return err;
+  }
+  return DefaultReceiver();
 }
 }  // namespace reduct::api

--- a/src/reduct/auth/token_auth.h
+++ b/src/reduct/auth/token_auth.h
@@ -13,6 +13,13 @@
 namespace reduct::auth {
 
 /**
+ * Parse token from authorization header
+ * @param authorization_header
+ * @return
+ */
+core::Result<std::string> ParseBearerToken(std::string_view authorization_header);
+
+/**
  *  Authorization by token
  */
 class ITokenAuthorization {
@@ -30,6 +37,12 @@ class ITokenAuthorization {
   virtual core::Error Check(std::string_view authorization_header, const ITokenRepository& repository,
                             const IAuthorizationPolicy& policy) const = 0;
 
+  /**
+   * @brief Build authorization instance
+   * @param api_token
+   * @param options
+   * @return
+   */
   static std::unique_ptr<ITokenAuthorization> Build(std::string_view api_token, Options options = Options{});
 };
 }  // namespace reduct::auth

--- a/src/reduct/core/error.h
+++ b/src/reduct/core/error.h
@@ -34,12 +34,14 @@ struct [[nodiscard]] Error {  // NOLINT
 
   enum Codes {
     kContinue = 100,
+    kNoContent = 202,  // 204 is used by HTTP
     kBadRequest = 400,
     kUnauthorized = 401,
     kForbidden = 403,
     kNotFound = 404,
     kMethodNotAllowed = 405,
     kConflict = 409,
+    kPayloadTooLarge = 413,
     kContentLengthRequired = 411,
     kUnprocessableEntity = 422,
     kPreconditionFailed = 412,
@@ -63,6 +65,9 @@ struct [[nodiscard]] Error {  // NOLINT
   static Error Conflict(std::string msg = "Conflict") { return Error{kConflict, std::move(msg)}; }
   static Error ContentLengthRequired(std::string msg = "Content Length Required") {
     return Error{kContentLengthRequired, std::move(msg)};
+  }
+  static Error PayloadTooLarge(std::string msg = "Payload Too Large") {
+    return Error{kPayloadTooLarge, std::move(msg)};
   }
   static Error UnprocessableEntity(std::string msg = "Unprocessable Entity") {
     return Error{kUnprocessableEntity, std::move(msg)};

--- a/unit_tests/reduct/api/bucket_api_test.cc
+++ b/unit_tests/reduct/api/bucket_api_test.cc
@@ -74,10 +74,7 @@ TEST_CASE("BucketApi::GetBucket should get a bucket") {
   }
 
   SECTION("doesn't exist") {
-    auto [receiver, err] = BucketApi::GetBucket(storage.get(), "bucket");
-    REQUIRE(err == Error::kOk);
-
-    REQUIRE(receiver("", true).error == Error::NotFound("Bucket 'bucket' is not found"));
+    REQUIRE(BucketApi::GetBucket(storage.get(), "bucket").error == Error::NotFound("Bucket 'bucket' is not found"));
   }
 }
 
@@ -119,10 +116,7 @@ TEST_CASE("BucketApi::UpdateBucket should update a bucket") {
   }
 
   SECTION("doesn't exist") {
-    auto [receiver, err] = BucketApi::UpdateBucket(storage.get(), "bucket");
-    REQUIRE(err == Error::kOk);
-
-    REQUIRE(receiver("", true).error == Error::NotFound("Bucket 'bucket' is not found"));
+    REQUIRE(BucketApi::UpdateBucket(storage.get(), "bucket").error == Error::NotFound("Bucket 'bucket' is not found"));
   }
 
   SECTION("bad syntax") {
@@ -173,9 +167,7 @@ TEST_CASE("BucketApi::RemoveBucket should remove a bucket") {
   }
 
   SECTION("doesn't exist") {
-    auto [receiver, err] = BucketApi::RemoveBucket(storage.get(), repo.get(), "bucket");
-    REQUIRE(err == Error::kOk);
-
-    REQUIRE(receiver("", true) == Error::NotFound("Bucket 'bucket' is not found"));
+    REQUIRE(BucketApi::RemoveBucket(storage.get(), repo.get(), "bucket").error ==
+            Error::NotFound("Bucket 'bucket' is not found"));
   }
 }

--- a/unit_tests/reduct/api/entry_api_test.cc
+++ b/unit_tests/reduct/api/entry_api_test.cc
@@ -42,63 +42,44 @@ TEST_CASE("EntryApi::Write should write data in chunks") {
     }
 
     SECTION("record already exists") {
-      auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "10");
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error == Error{
-                                              .code = 409,
-                                              .message = "A record with timestamp 1000001 already exists",
-                                          });
+      REQUIRE(EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "10").error ==
+              Error::Conflict("A record with timestamp 1000001 already exists"));
     }
   }
 
   SECTION("wrong ts") {
-    auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "XXXX", "10");
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error ==
-            Error{
-                .code = 422,
-                .message = "Failed to parse 'ts' parameter: XXXX must unix times in microseconds",
-            });
+    REQUIRE(EntryApi::Write(storage.get(), "bucket", "entry-1", "XXXX", "10").error ==
+            Error::UnprocessableEntity("Failed to parse 'ts' parameter: XXXX must unix times in microseconds"));
   }
 
   SECTION("negative ts") {
-    auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "-100", "10");
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 422,
-                                            .message = "Failed to parse 'ts' parameter: -100 must be positive",
-                                        });
+    REQUIRE(EntryApi::Write(storage.get(), "bucket", "entry-1", "-100", "10").error ==
+            Error::UnprocessableEntity("Failed to parse 'ts' parameter: -100 must be positive"));
   }
 
   SECTION("empty entry") {
-    auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "", "1000001", "10");
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 422,
-                                            .message = "An empty entry name is not allowed",
-                                        });
+    REQUIRE(EntryApi::Write(storage.get(), "bucket", "", "1000001", "10").error ==
+            Error::UnprocessableEntity("An empty entry name is not allowed"));
   }
 
   SECTION("wrong content-length") {
     auto entry = storage->GetBucket("bucket").result.lock()->GetOrCreateEntry("entry-1").result.lock();
 
     SECTION("empty") {
-      auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "");
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error == Error::ContentLengthRequired("Bad or empty content-length"));
+      REQUIRE(EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "").error ==
+              Error::ContentLengthRequired("Bad or empty content-length"));
     }
 
     SECTION("negative") {
-      auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "-1");
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error == Error::ContentLengthRequired("Negative content-length"));
+      REQUIRE(EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "-1").error ==
+              Error::ContentLengthRequired("Negative content-length"));
     }
 
     SECTION("no number") {
-      auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "xxxx");
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error == Error::ContentLengthRequired("Bad or empty content-length"));
+      REQUIRE(EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "xxxx").error ==
+              Error::ContentLengthRequired("Bad or empty content-length"));
     }
+
     REQUIRE(entry->BeginRead(reduct::core::Time() + us(1000001)).error.code == 404);
   }
 
@@ -120,14 +101,8 @@ TEST_CASE("EntryApi::Write should write data in chunks") {
     }
 
     SECTION("too short") {
-      REQUIRE(receiver("1234", true).error == Error{
-                                                  .code = 413,
-                                                  .message = "Content is smaller than in content-length",
-                                              });
-      REQUIRE(entry->BeginRead(reduct::core::Time() + us(1000001)).error == Error{
-                                                                                .code = 500,
-                                                                                .message = "Record is broken",
-                                                                            });
+      REQUIRE(receiver("1234", true).error == Error(413, "Content is smaller than in content-length"));
+      REQUIRE(entry->BeginRead(reduct::core::Time() + us(1000001)).error == Error::InternalError("Record is broken"));
     }
   }
 }
@@ -157,42 +132,23 @@ TEST_CASE("EntryApi::Read should read data in chunks with time") {
   }
 
   SECTION("bucket doesn't exist") {
-    auto [receiver, err] = EntryApi::Read(storage.get(), "XXX", "entry-1", "1000001", {});
-    REQUIRE(err == Error::kOk);
-
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 404,
-                                            .message = "Bucket 'XXX' is not found",
-                                        });
+    REQUIRE(EntryApi::Read(storage.get(), "XXX", "entry-1", "1000001", {}).error ==
+            Error::NotFound("Bucket 'XXX' is not found"));
   }
 
   SECTION("entry doesn't exist") {
-    auto [receiver, err] = EntryApi::Read(storage.get(), "bucket", "XXX", "1000001", {});
-    REQUIRE(err == Error::kOk);
-
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 404,
-                                            .message = "Entry 'XXX' is not found",
-                                        });
+    REQUIRE(EntryApi::Read(storage.get(), "bucket", "XXX", "1000001", {}).error ==
+            Error::NotFound("Entry 'XXX' is not found"));
   }
 
   SECTION("record doesn't exist") {
-    auto [receiver, err] = EntryApi::Read(storage.get(), "bucket", "entry-1", "1234567", {});
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 404,
-                                            .message = "No records for this timestamp",
-                                        });
+    REQUIRE(EntryApi::Read(storage.get(), "bucket", "entry-1", "1234567", {}).error ==
+            Error::NotFound("No records for this timestamp"));
   }
 
   SECTION("wrong ts") {
-    auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "XXXX", {});
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error ==
-            Error{
-                .code = 422,
-                .message = "Failed to parse 'ts' parameter: XXXX must unix times in microseconds",
-            });
+    REQUIRE(EntryApi::Write(storage.get(), "bucket", "entry-1", "XXXX", {}).error ==
+            Error::UnprocessableEntity("Failed to parse 'ts' parameter: XXXX must unix times in microseconds"));
   }
 }
 
@@ -239,31 +195,18 @@ TEST_CASE("EntryApi::Read should read data in chunks with query id") {
       REQUIRE(ret.result == "abcd");
     }
 
-    {
-      auto [receiver, err] = EntryApi::Read(storage.get(), "bucket", "entry-1", {}, id);
-      REQUIRE(err == Error::kOk);
-
-      REQUIRE(receiver("", true).error ==
-              Error{.code = 404, .message = fmt::format("Query id={} doesn't exist. It expired or was finished", id)});
-    }
+    REQUIRE(EntryApi::Read(storage.get(), "bucket", "entry-1", {}, id).error ==
+            Error::NotFound(fmt::format("Query id={} doesn't exist. It expired or was finished", id)));
   }
 
   SECTION("id doesnt' exist") {
-    auto [receiver, err] = EntryApi::Read(storage.get(), "bucket", "entry-1", {}, "2");
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 404,
-                                            .message = "Query id=2 doesn't exist. It expired or was finished",
-                                        });
+    REQUIRE(EntryApi::Read(storage.get(), "bucket", "entry-1", {}, "2").error ==
+            Error::NotFound("Query id=2 doesn't exist. It expired or was finished"));
   }
 
   SECTION("wrong id") {
-    auto [receiver, err] = EntryApi::Read(storage.get(), "bucket", "entry-1", {}, "XXX2");
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 422,
-                                            .message = "Failed to parse 'id' parameter: XXX2 must be unsigned integer",
-                                        });
+    REQUIRE(EntryApi::Read(storage.get(), "bucket", "entry-1", {}, "XXX2").error ==
+            Error::UnprocessableEntity("Failed to parse 'id' parameter: XXX2 must be unsigned integer"));
   }
 }
 
@@ -289,7 +232,7 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
 
     REQUIRE(entry->Next(info.id()).error == Error::kOk);
     REQUIRE(entry->Next(info.id()).error == Error::kOk);
-    REQUIRE(entry->Next(info.id()).error.code == 404);
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
   }
 
   SECTION("ok start") {
@@ -302,7 +245,7 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
     JsonStringToMessage(resp.SendData().result, &info);
 
     REQUIRE(entry->Next(info.id()).result.reader->timestamp() == Time() + us(2000001));
-    REQUIRE(entry->Next(info.id()).error.code == 404);
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
   }
 
   SECTION("ok stop") {
@@ -315,7 +258,7 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
     JsonStringToMessage(resp.SendData().result, &info);
 
     REQUIRE(entry->Next(info.id()).result.reader->timestamp() == Time() + us(1000001));
-    REQUIRE(entry->Next(info.id()).error.code == 404);
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
   }
 
   SECTION("ok timeinterval") {
@@ -327,8 +270,8 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
 
     JsonStringToMessage(resp.SendData().result, &info);
 
-    REQUIRE(entry->Next(info.id()).error.code == 202);  // no content
-    REQUIRE(entry->Next(info.id()).error.code == 404);
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNoContent);  // no content
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
   }
 
   SECTION("ok ttl") {
@@ -336,63 +279,29 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
     REQUIRE(err == Error::kOk);
 
     std::this_thread::sleep_for(us(1'000'000));
-    REQUIRE(entry->Next(info.id()).error.code == 404);
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
   }
 
   SECTION("bucket doesn't exist") {
-    auto [receiver, err] = EntryApi::Query(storage.get(), "XXX", "entry-1", {}, {}, {});
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 404,
-                                            .message = "Bucket 'XXX' is not found",
-                                        });
+    REQUIRE(EntryApi::Query(storage.get(), "XXX", "entry-1", {}, {}, {}).error ==
+            Error::NotFound("Bucket 'XXX' is not found"));
   }
 
   SECTION("entry doesn't exist") {
-    auto [receiver, err] = EntryApi::Query(storage.get(), "bucket", "XXX", {}, {}, {});
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver("", true).error == Error{
-                                            .code = 404,
-                                            .message = "Entry 'XXX' is not found",
-                                        });
+    REQUIRE(EntryApi::Query(storage.get(), "bucket", "XXX", {}, {}, {}).error ==
+            Error::NotFound("Entry 'XXX' is not found"));
   }
 
   SECTION("wrong parameters") {
-    {
-      auto [receiver, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", "XXX", {}, {});
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error ==
-              Error{
-                  .code = 422,
-                  .message = "Failed to parse 'start_timestamp' parameter: XXX must unix times in microseconds",
-              });
-    }
-    {
-      auto [receiver, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", {}, "XXX", {});
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error ==
-              Error{
-                  .code = 422,
-                  .message = "Failed to parse 'stop_timestamp' parameter: XXX must unix times in microseconds",
-              });
-    }
-    {
-      auto [receiver, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {}, "XXX");
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error ==
-              Error{
-                  .code = 422,
-                  .message = "Failed to parse 'ttl' parameter: XXX must be unsigned integer",
-              });
-    }
-    {
-      auto [receiver, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {}, "XXX");
-      REQUIRE(err == Error::kOk);
-      REQUIRE(receiver("", true).error ==
-              Error{
-                  .code = 422,
-                  .message = "Failed to parse 'ttl' parameter: XXX must be unsigned integer",
-              });
-    }
+    REQUIRE(
+        EntryApi::Query(storage.get(), "bucket", "entry-1", "XXX", {}, {}).error ==
+        Error::UnprocessableEntity("Failed to parse 'start_timestamp' parameter: XXX must unix times in microseconds"));
+    REQUIRE(
+        EntryApi::Query(storage.get(), "bucket", "entry-1", {}, "XXX", {}).error ==
+        Error::UnprocessableEntity("Failed to parse 'stop_timestamp' parameter: XXX must unix times in microseconds"));
+    REQUIRE(EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {}, "XXX").error ==
+            Error::UnprocessableEntity("Failed to parse 'ttl' parameter: XXX must be unsigned integer"));
+    REQUIRE(EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {}, "XXX").error ==
+            Error::UnprocessableEntity("Failed to parse 'ttl' parameter: XXX must be unsigned integer"));
   }
 }

--- a/unit_tests/reduct/api/server_api_test.cc
+++ b/unit_tests/reduct/api/server_api_test.cc
@@ -63,9 +63,17 @@ TEST_CASE("ServerApi::List should return JSON") {
 }
 
 TEST_CASE("ServerAPI::Me should return current permissions") {
-  auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
+  auto repo = ITokenRepository::Build({.data_path = BuildTmpDirectory()});
 
-  auto [receiver, err] = ServerApi::Me(storage.get());
+  ITokenRepository::TokenPermissions permissions;
+  permissions.set_full_access(true);
+  permissions.mutable_read()->Add("bucket-1");
+  permissions.mutable_write()->Add("bucket-2");
+
+  auto [token_value, creat_err] = repo->CreateToken("token-1", permissions);
+  REQUIRE(creat_err == Error::kOk);
+
+  auto [receiver, err] = ServerApi::Me(repo.get(), fmt::format("Bearer {}", token_value.value()));
   REQUIRE(err == Error::kOk);
 
   auto [resp, recv_err] = receiver("", true);
@@ -74,10 +82,21 @@ TEST_CASE("ServerAPI::Me should return current permissions") {
   auto output = resp.SendData();
   REQUIRE(output.error == Error::kOk);
 
-  reduct::proto::api::TokenPermissions permissions;
-  JsonStringToMessage(output.result, &permissions);
+  ITokenRepository::Token token;
+  JsonStringToMessage(output.result, &token);
 
-  REQUIRE(permissions.full_access());
-  REQUIRE(permissions.read().empty());
-  REQUIRE(permissions.write().empty());
+  REQUIRE(token.name() == "token-1");
+  REQUIRE(token.permissions().full_access());
+  REQUIRE(token.permissions().read().size() == 1);
+  REQUIRE(token.permissions().read(0) == "bucket-1");
+  REQUIRE(token.permissions().write().size() == 1);
+  REQUIRE(token.permissions().write(0) == "bucket-2");
+
+  SECTION("invalid token") {
+    REQUIRE(ServerApi::Me(repo.get(), "Bearer XXXX").error == Error::Unauthorized("Invalid token"));
+  }
+
+  SECTION("no token") {
+    REQUIRE(ServerApi::Me(repo.get(), "").error == Error::Unauthorized("No bearer token in request header"));
+  }
 }

--- a/unit_tests/reduct/api/token_api_test.cc
+++ b/unit_tests/reduct/api/token_api_test.cc
@@ -114,9 +114,7 @@ TEST_CASE("TokenApi::GetToken should show a token") {
   }
 
   SECTION("not found") {
-    auto [receiver, err] = TokenApi::GetToken(repo.get(), "XXXX");
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver({}, true).error == Error::NotFound("Token 'XXXX' doesn't exist"));
+    REQUIRE(TokenApi::GetToken(repo.get(), "XXXX").error == Error::NotFound("Token 'XXXX' doesn't exist"));
   }
 }
 
@@ -135,8 +133,6 @@ TEST_CASE("TokenApi::RemoveToken should delete a token") {
   }
 
   SECTION("not found") {
-    auto [receiver, err] = TokenApi::RemoveToken(repo.get(), "XXXX");
-    REQUIRE(err == Error::kOk);
-    REQUIRE(receiver({}, true).error == Error::NotFound("Token 'XXXX' doesn't exist"));
+    REQUIRE(TokenApi::RemoveToken(repo.get(), "XXXX").error == Error::NotFound("Token 'XXXX' doesn't exist"));
   }
 }


### PR DESCRIPTION
Closes #202 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

A client cannot figure out its permissions

### What is the new behavior?

Method `GET /api/v1/me` returns full information about the current token in the Authorization header:

```json
{
"name":"init-token",
"value":"",
  "permissions":{"full_access":true,"read":[],"write":[]},
  "created_at":"2022-12-11T22:21:33Z"
}
```


### Does this PR introduce a breaking change?

No

### Other information:
