### PR TITLE
Send error message in `-x-reduct-error`header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GET /api/v1/me` endpoint to get current
   permissions, [PR-202](https://github.com/reduct-storage/reduct-storage/pull/208)
+- Send error message in `-x-reduct-error`header [PR-213](https://github.com/reduct-storage/reduct-storage/pull/213)
 
 ### Changed:
 

--- a/api_tests/auth_test.py
+++ b/api_tests/auth_test.py
@@ -1,5 +1,5 @@
 """Test authorization"""
-from conftest import get_detail, requires_env, auth_headers
+from conftest import requires_env, auth_headers
 
 
 @requires_env("API_TOKEN")
@@ -14,7 +14,7 @@ def test__compare_api_token(base_url, session):
     """should compare token"""
     resp = session.get(f'{base_url}/info', headers=auth_headers('ABCB0001'))
     assert resp.status_code == 401
-    assert get_detail(resp) == "Invalid token"
+    assert resp.headers["-x-reduct-error"] == "Invalid token"
 
 
 @requires_env("API_TOKEN")
@@ -22,4 +22,4 @@ def test__empty_token(base_url, session):
     """should use Bearer token"""
     resp = session.get(f'{base_url}/info', headers={'Authorization': ''})
     assert resp.status_code == 401
-    assert get_detail(resp) == "No bearer token in request header"
+    assert resp.headers["-x-reduct-error"] == "No bearer token in request header"

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -1,6 +1,6 @@
 import json
 
-from conftest import get_detail, requires_env, auth_headers
+from conftest import requires_env, auth_headers
 
 
 def test__create_bucket_ok(base_url, session, bucket_name):
@@ -59,14 +59,14 @@ def test__create_twice_bucket(base_url, session, bucket_name):
     resp = session.post(f'{base_url}/b/{bucket_name}')
 
     assert resp.status_code == 409
-    assert "already exists" in get_detail(resp)
+    assert "already exists" in resp.headers["-x-reduct-error"]
 
 
 def test__get_bucket_not_exist(base_url, session, bucket_name):
     """Should return error if the bucket is not found"""
     resp = session.get(f'{base_url}/b/{bucket_name}')
     assert resp.status_code == 404
-    assert "is not found" in get_detail(resp)
+    assert "is not found" in resp.headers["-x-reduct-error"]
 
 
 @requires_env("API_TOKEN")
@@ -182,7 +182,7 @@ def test__remove_bucket_not_exist(base_url, session, bucket_name):
     """Should return an error if  bucket doesn't exist"""
     resp = session.delete(f'{base_url}/b/{bucket_name}')
     assert resp.status_code == 404
-    assert "is not found" in get_detail(resp)
+    assert "is not found" in resp.headers["-x-reduct-error"]
 
 
 @requires_env("API_TOKEN")

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -23,10 +23,6 @@ def _gen_bucket_name() -> str:
     return f'bucket_{random.randint(0, 1000000)}'
 
 
-def get_detail(resp) -> str:
-    return json.loads(resp.content)["detail"]
-
-
 def requires_env(key):
     env = os.environ.get(key)
 

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 import pytest
 
-from conftest import get_detail, requires_env, auth_headers
+from conftest import requires_env, auth_headers
 
 
 @pytest.fixture(name='bucket')
@@ -47,7 +47,7 @@ def test_read_no_bucket(base_url, session):
     """Should return 404 if no bucket found"""
     resp = session.get(f'{base_url}/b/xxx/entry?ts=100')
     assert resp.status_code == 404
-    assert 'xxx' in get_detail(resp)
+    assert 'xxx' in resp.headers["-x-reduct-error"]
 
 
 def test_read_no_data(base_url, session, bucket):
@@ -62,14 +62,14 @@ def test_read_bad_ts(base_url, session, bucket):
     resp = session.get(f'{base_url}/b/{bucket}/entry?ts=XXXX')
 
     assert resp.status_code == 422
-    assert 'XXX' in get_detail(resp)
+    assert 'XXX' in resp.headers["-x-reduct-error"]
 
 
 def test_read_bad_no_entry(base_url, session, bucket):
     """Should return 400 if ts is bad"""
     resp = session.get(f'{base_url}/b/{bucket}/entry')
     assert resp.status_code == 404
-    assert 'entry' in get_detail(resp)
+    assert 'entry' in resp.headers["-x-reduct-error"]
 
 
 @requires_env("API_TOKEN")
@@ -93,14 +93,14 @@ def test_write_no_bucket(base_url, session):
     """Should return 404 if no bucket found"""
     resp = session.post(f'{base_url}/b/xxx/entry?ts=100')
     assert resp.status_code == 404
-    assert 'xxx' in get_detail(resp)
+    assert 'xxx' in resp.headers["-x-reduct-error"]
 
 
 def test_write_bad_ts(base_url, session, bucket):
     """Should return 422 if ts is bad"""
     resp = session.post(f'{base_url}/b/{bucket}/entry?ts=XXXX')
     assert resp.status_code == 422
-    assert 'XXX' in get_detail(resp)
+    assert 'XXX' in resp.headers["-x-reduct-error"]
 
 
 def test_get_record_ok(base_url, session, bucket):
@@ -159,6 +159,7 @@ def test_write_big_blob_with_error(base_url, session, bucket):
 
     resp = session.get(f'{base_url}/b/{bucket}/entry')
     assert resp.status_code == 200
+
 
 @requires_env("API_TOKEN")
 def test__write_with_write_token(base_url, session, bucket, token_without_permissions, token_read_bucket,

--- a/api_tests/token_api_test.py
+++ b/api_tests/token_api_test.py
@@ -1,6 +1,6 @@
 import json
 
-from conftest import get_detail, auth_headers, requires_env
+from conftest import auth_headers, requires_env
 
 
 def test__create_token(base_url, session, token_name, bucket_name):
@@ -28,7 +28,7 @@ def test__create_token_exist(base_url, session, token_name):
     assert resp.status_code == 200
     resp = session.post(f'{base_url}/tokens/{token_name}')
     assert resp.status_code == 409
-    assert get_detail(resp) == f"Token '{token_name}' already exists"
+    assert resp.headers["-x-reduct-error"] == f"Token '{token_name}' already exists"
 
 
 @requires_env("API_TOKEN")
@@ -42,7 +42,7 @@ def test__creat_token_with_full_access(base_url, session, token_name, token_with
     resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions,
                         headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert get_detail(resp) == "Token doesn't have full access"
+    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"
 
 
 def test__list_tokens(base_url, session, token_name):
@@ -66,7 +66,7 @@ def test__list_token_with_full_access(base_url, session, token_without_permissio
 
     resp = session.get(f'{base_url}/tokens', headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert get_detail(resp) == "Token doesn't have full access"
+    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"
 
 
 def test__get_token(base_url, session, bucket_name, token_name):
@@ -99,7 +99,7 @@ def test__get_token_not_found(base_url, session):
     """Should return 404 if a token does not exist"""
     resp = session.get(f'{base_url}/tokens/token-not-found')
     assert resp.status_code == 404
-    assert get_detail(resp) == "Token 'token-not-found' doesn't exist"
+    assert resp.headers["-x-reduct-error"] == "Token 'token-not-found' doesn't exist"
 
 
 @requires_env("API_TOKEN")
@@ -110,7 +110,7 @@ def test__get_token_with_full_access(base_url, session, token_without_permission
 
     resp = session.get(f'{base_url}/tokens/token-name', headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert get_detail(resp) == "Token doesn't have full access"
+    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"
 
 
 def test__delete_token(base_url, session, token_name):
@@ -132,7 +132,7 @@ def test__delete_token_not_found(base_url, session):
     """Should return 404 if a token does not exist"""
     resp = session.delete(f'{base_url}/tokens/token-not-found')
     assert resp.status_code == 404
-    assert get_detail(resp) == "Token 'token-not-found' doesn't exist"
+    assert resp.headers["-x-reduct-error"] == "Token 'token-not-found' doesn't exist"
 
 
 @requires_env("API_TOKEN")
@@ -143,4 +143,4 @@ def test__delete_token_with_full_access(base_url, session, token_without_permiss
 
     resp = session.delete(f'{base_url}/tokens/token-name', headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert get_detail(resp) == "Token doesn't have full access"
+    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 * [💡 Getting Started](README.md)
 * [😯 How Does It Work?](how-does-it-work.md)
-* [⚙ HTTP API](http-api/README.md)
+* [⚙ HTTP API Reference](http-api/README.md)
   * [Server API](http-api/server-api.md)
   * [Bucket API](http-api/bucket-api.md)
   * [Entry API](http-api/entry-api.md)

--- a/docs/http-api/README.md
+++ b/docs/http-api/README.md
@@ -1,6 +1,26 @@
----
-description: Here you can learn everything about Reduct Storage's HTTP API
----
+# ⚙ HTTP API Reference
 
-# ⚙ HTTP API
+Reduct Storage provides a simple HTTP API for interacting with the database. In order to use the API, you must first authenticate using a token, which you can be provisioned  one with the `RS_API_TOKEN`[environment variable ](../#environment-variables)or created with [the Token API](token-authentication.md).
+
+Once you have obtained a token, you can use it to authenticate your requests by including it in the `Authorization` header of your HTTP request, like this:
+
+```
+Authorization: Bearer <your-token-here>
+```
+
+An example of a request with CURL:
+
+```shell
+ curl   --header "Authorization: Bearer ${ACCESS_TOKEN}" -a http://127.0.0.1:8383/api/v1/info
+```
+
+{% hint style="info" %}
+The storage engine uses the token authentication when the`RS_API_TOKEN` envirnoment is set. You should use it as a full access token to create other tokens with different permission by using the Token API
+{% endhint %}
+
+## **Handling Errors**
+
+If a request to Reduct Storage fails, the API  returns an HTTP status code indicating the type of error that occurred. For example, a `404 Not Found` status code indicates that the requested resource could not be found.
+
+Since version 1.2.0, the HTTP API also includes an error message in the `-x-reduct-error` header of the response. This error message provides more detailed information about the error, which can be useful for debugging and troubleshooting.
 

--- a/docs/http-api/bucket-api.md
+++ b/docs/http-api/bucket-api.md
@@ -1,17 +1,19 @@
 ---
-description: Bucket API provides HTTP methods to create, modify or delete a bucket
+description: HTTP methods to manage buckets with data
 ---
 
 # Bucket API
 
-Before starting recording, a user has to create a bucket with the following settings:
+The Bucket API allows users to create, modify, and delete buckets.
+
+Before starting to record data, a user must first create a bucket and specify settings such as:
 
 * Maximum block size
 * Maximum number of records
 * Quota type
 * Quota size
 
-For more information, you can read more about buckets in [How does it work?](../how-does-it-work.md)
+For more information about buckets, read  [here](../how-does-it-work.md#internal-structure).
 
 {% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Get information about a bucket" %}
 {% swagger-description %}
@@ -70,8 +72,6 @@ Name of bucket
 {% endswagger-response %}
 {% endswagger %}
 
-
-
 {% swagger method="head" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Check if a bucket exists" %}
 {% swagger-description %}
 If authenticaion is enabled, the method needs a valid API token.
@@ -105,8 +105,6 @@ Name of bucket
 ```
 {% endswagger-response %}
 {% endswagger %}
-
-
 
 {% swagger method="post" path=" " baseUrl="/api/v1/b/:bucket_name  " summary="Create a new bucket" %}
 {% swagger-description %}
@@ -151,7 +149,7 @@ Size of quota in bytes (default: 0)
 ```
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn't have full access" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn" %}
 ```javascript
 {
     "detail": "error_message"
@@ -175,8 +173,6 @@ Size of quota in bytes (default: 0)
 ```
 {% endswagger-response %}
 {% endswagger %}
-
-
 
 {% swagger method="put" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Change settings of a bucket" %}
 {% swagger-description %}
@@ -221,7 +217,7 @@ Size of quota in bytes
 ```
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn't have full access" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn" %}
 ```javascript
 {
     "detail": "error_message"
@@ -245,8 +241,6 @@ Size of quota in bytes
 ```
 {% endswagger-response %}
 {% endswagger %}
-
-
 
 {% swagger method="delete" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Remove a bucket" %}
 {% swagger-description %}
@@ -275,7 +269,7 @@ Name of bucket to remove
 ```
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn't have full access" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn" %}
 ```javascript
 {
     // Response
@@ -291,4 +285,3 @@ Name of bucket to remove
 ```
 {% endswagger-response %}
 {% endswagger %}
-

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -1,6 +1,12 @@
+---
+description: HTTP methods to read, write and query entry records
+---
+
 # Entry API
 
-**Entry API**
+The Entry API allows users to write and read data from their buckets, as well as search for specific entries using query operations.
+
+
 
 {% swagger method="post" path=" " baseUrl="/api/v1/b/:bucket_name/:entry_name" summary="Write a record to an entry" %}
 {% swagger-description %}
@@ -231,4 +237,3 @@ Time To Live of the query in seconds. If a client haven't read any record for th
 ```
 {% endswagger-response %}
 {% endswagger %}
-

--- a/docs/http-api/server-api.md
+++ b/docs/http-api/server-api.md
@@ -1,8 +1,10 @@
 ---
-description: Server API provides information about the storage and its state
+description: HTTP methods to get information about a Reduct Storage instance
 ---
 
 # Server API
+
+The server API provides HTTP methods for checking the status of the server, listing the available buckets, and retrieving the permissions for the current API token.
 
 {% swagger method="get" path=" " baseUrl="/api/v1/info" summary="Get statistical information about the storage" %}
 {% swagger-description %}

--- a/docs/http-api/token-authentication.md
+++ b/docs/http-api/token-authentication.md
@@ -1,24 +1,8 @@
 ---
-description: >-
-  Here you can find how to access to storage with access tokens and use  the
-  Token API to manage them
+description: HTTP methods to manage access tokens.
 ---
 
 # Token API
-
-### Access Token
-
-Reduct Storage uses a simple authentication model with a bearer token. This token should be sent as the`Authorization` header in the following format:
-
-```
-Bearer <ACCESS_TOKEN>
-```
-
-An example of a request with CURL:
-
-```shell
- curl   --header "Authorization: Bearer ${ACCESS_TOKEN}" -a http://127.0.0.1:8383/api/v1/info
-```
 
 {% hint style="info" %}
 The storage engine uses the token authentication when the`RS_API_TOKEN` envirnoment is set. You should use it as a full access token to create other tokens with different permission by using the Token API
@@ -161,7 +145,7 @@ A list of bucket names for write access. Default: []
 ```
 {% endswagger-response %}
 
-{% swagger-response status="422: Unprocessable Entity" description="Speciefied bucket doesn't exist" %}
+{% swagger-response status="422: Unprocessable Entity" description="Speciefied bucket doesn" %}
 ```javascript
 {
     // Response
@@ -169,8 +153,6 @@ A list of bucket names for write access. Default: []
 ```
 {% endswagger-response %}
 {% endswagger %}
-
-
 
 {% swagger method="delete" path="" baseUrl="/api/v1/tokens/:token_name" summary="Remove a  token" %}
 {% swagger-description %}

--- a/src/reduct/api/bucket_api.cc
+++ b/src/reduct/api/bucket_api.cc
@@ -37,15 +37,10 @@ Result<HttpRequestReceiver> BucketApi::GetBucket(const IStorage* storage, std::s
 core::Result<HttpRequestReceiver> BucketApi::HeadBucket(const storage::IStorage* storage, std::string_view name) {
   auto [bucket_ptr, err] = storage->GetBucket(std::string(name));
   if (err) {
-    err.message = "";
+    return err;
   }
 
-  return {
-      [err = std::move(err)](std::string_view chunk, bool last) -> core::Result<HttpResponse> {
-        return {HttpResponse::Default(), err};
-      },
-      core::Error::kOk,
-  };
+  return DefaultReceiver();
 }
 
 core::Result<HttpRequestReceiver> BucketApi::UpdateBucket(const storage::IStorage* storage, std::string_view name) {

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -149,7 +149,8 @@ class HttpServer : public IHttpServer {
       ctx.res->writeStatus(std::to_string(err.code));
       CommonHeaders();
       ctx.res->writeHeader("content-type", "application/json");
-      if (err.message.empty()) {
+      ctx.res->writeHeader("-x-reduct-error", err.message);
+      if (method == "HEAD") {
         ctx.res->end({});
       } else {
         ctx.res->end(fmt::format(R"({{"detail":"{}"}})", err.message));

--- a/unit_tests/reduct/api/bucket_api_test.cc
+++ b/unit_tests/reduct/api/bucket_api_test.cc
@@ -94,10 +94,7 @@ TEST_CASE("BucketApi::HeadBucket should get a bucket") {
   }
 
   SECTION("doesn't exist") {
-    auto [receiver, err] = BucketApi::HeadBucket(storage.get(), "bucket");
-    REQUIRE(err == Error::kOk);
-
-    REQUIRE(receiver("", true).error == Error::NotFound(""));
+    REQUIRE(BucketApi::HeadBucket(storage.get(), "bucket").error == Error::NotFound("Bucket 'bucket' is not found"));
   }
 }
 


### PR DESCRIPTION
Closes #197 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

See #197 

### What is the new behavior?

We use `-x-reduct-error`header for an error message. Th JSON document in the body is still working, but it is deprecated. 


### Does this PR introduce a breaking change?

No

### Other information:
